### PR TITLE
Add environmental variable for SwaggerHub URL

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,5 +1,15 @@
 const { updateJSONSync, readJSONSync } = require('../support/fs')
 
+const checkUrlOverride = config => {
+  if (process.env.SWAGGERHUB_URL) {
+    return {
+      ...config,
+      swaggerHubUrl: process.env.SWAGGERHUB_URL
+    }
+  }
+  return config
+}
+
 const checkApiKeyOverride = config => {
   if (process.env.SWAGGERHUB_API_KEY) {
     return {
@@ -13,9 +23,9 @@ const checkApiKeyOverride = config => {
 const getConfig = () => {
   const { configFilePath } = global
   
-  return checkApiKeyOverride (
-    readJSONSync(configFilePath)
-  )
+  return checkUrlOverride(
+    checkApiKeyOverride(
+      readJSONSync(configFilePath)))
 }
 
 const setConfig = update => {

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -2,8 +2,10 @@ const { expect, test } = require('@oclif/test')
 const { writeJSONSync, deleteFileSync, readJSONSync } = require('../../src/support/fs')
 const mock = require('../__mocks__/config')
 const isEqual = require('lodash/isEqual')
-
 const { setConfig, getConfig } = require('../../src/services/config')
+
+const envShubUrl = 'https://environmental.var'
+const envApiKey = 'api-key-from-env-variable'
 
 describe('config ', () => {
   beforeEach(() => {
@@ -29,25 +31,36 @@ describe('config ', () => {
         .to.equal(true)
     })
   })
-  
+
   describe('getConfig', () => {
     test.it('it should return the contents of config file', () => {
       expect(isEqual(getConfig(), mock.config)).to.equal(true)
     })
 
     test
-      .env({ SWAGGERHUB_API_KEY: mock.config.apiKey })
-      .it('should return the configured API key from environmental variable', () => {    
-        expect(getConfig().apiKey).to.equal(mock.config.apiKey)
-        delete process.env.SWAGGERHUB_API_KEY
-      })
-  
+    .env({ SWAGGERHUB_URL: envShubUrl })
+    .it('should return the configured SwaggerHub URL from environmental variable', () => {    
+      expect(getConfig().swaggerHubUrl).to.equal(envShubUrl)
+    })
+
     test
-      .env({ SWAGGERHUB_API_KEY: mock.config.apiKey })
-      .it('should prioritise environmental variable API key', () => {
-        setConfig({ apiKey: 'abcdef00-file-1234-5678-97e0b583f1b9' })
-        expect(getConfig().apiKey).to.equal(mock.config.apiKey)
-        delete process.env.SWAGGERHUB_API_KEY
-      })
+    .env({ SWAGGERHUB_URL: envShubUrl })
+    .it('should prioritise environmental variable SwaggerHub URL', () => {
+      setConfig({ apiKey: 'https://file.swaggerhub.com' })
+      expect(getConfig().swaggerHubUrl).to.equal(envShubUrl)
+    })
+
+    test
+    .env({ SWAGGERHUB_API_KEY: envApiKey })
+    .it('should return the configured API key from environmental variable', () => {    
+        expect(getConfig().apiKey).to.equal(envApiKey)
+    })
+
+    test
+    .env({ SWAGGERHUB_API_KEY: envApiKey })
+    .it('should prioritise environmental variable API key', () => {
+      setConfig({ apiKey: 'abcdef00-file-1234-5678-97e0b583f1b9' })
+      expect(getConfig().apiKey).to.equal(envApiKey)
+    })
   })
 })


### PR DESCRIPTION
Add reading of the environmental variable SWAGGERHUB_URL. This takes priority over the swaggerHubUrl property stored in config.