### PR TITLE
Removing static keyword to enable Node 10

### DIFF
--- a/src/commands/api/create.js
+++ b/src/commands/api/create.js
@@ -5,31 +5,6 @@ const { getIdentifierArg } = require('../../utils/input-validation')
 
 class CreateAPICommand extends Command {
   
-  static args = [{ 
-    name: 'identifier',
-    required: true,
-    description: 'identifier for API in {owner}/{api_name}/{version} format'
-  }]
-
-  static flags = {
-    file: flags.string({
-      char: 'f', 
-      description: 'file location of API to create',
-      required: true
-    }),
-    oas: flags.string({
-      description: 'OAS version of API',
-      options: ['2', '3'],
-      required: true,
-      parse: input => input === '2' ? '2.0' : '3.0.0'
-    }),
-    visibility: flags.string({
-      description: 'visibility of API in SwaggerHub',
-      options: ['public', 'private'],
-      default: 'private'
-    })
-  }
-
   async run() {
     const { args, flags } = this.parse(CreateAPICommand)
     const identifier = getIdentifierArg(args)
@@ -65,5 +40,30 @@ class CreateAPICommand extends Command {
 CreateAPICommand.description = `creates an API
 command will fail if the API already exists.
 `
+
+CreateAPICommand.args = [{ 
+  name: 'identifier',
+  required: true,
+  description: 'identifier for API in {owner}/{api_name}/{version} format'
+}]
+
+CreateAPICommand.flags = {
+  file: flags.string({
+    char: 'f', 
+    description: 'file location of API to create',
+    required: true
+  }),
+  oas: flags.string({
+    description: 'OAS version of API',
+    options: ['2', '3'],
+    required: true,
+    parse: input => input === '2' ? '2.0' : '3.0.0'
+  }),
+  visibility: flags.string({
+    description: 'visibility of API in SwaggerHub',
+    options: ['public', 'private'],
+    default: 'private'
+  })
+}
 
 module.exports = CreateAPICommand

--- a/src/commands/api/version/get.js
+++ b/src/commands/api/version/get.js
@@ -5,19 +5,7 @@ const { parseResponse, checkForErrors, handleErrors } = require('../../../utils/
 
 class GetAPICommand extends Command {
 
-  static args = [{ 
-    name: 'identifier',
-    required: true,
-    description: 'identifier for API in {owner}/{api_name}/{version} format'
-  },
-  ]
 
-  static flags = {
-    json: flags.boolean({
-      char: 'j',
-      description: 'returns the API in JSON format.'
-    })
-  }
 
   async run() {
     const { args, flags } = this.parse(GetAPICommand)
@@ -30,5 +18,18 @@ class GetAPICommand extends Command {
 }
 
 GetAPICommand.description = 'fetches an API version'
+
+GetAPICommand.flags = {
+  json: flags.boolean({
+    char: 'j',
+    description: 'returns the API in JSON format.'
+  })
+}
+
+GetAPICommand.args = [{ 
+  name: 'identifier',
+  required: true,
+  description: 'identifier for API in {owner}/{api_name}/{version} format'
+}]
 
 module.exports = GetAPICommand


### PR DESCRIPTION
Enables users with Node 10 installed to use the tool.

## Proposed Changes

* Removing static keyword to enable enable 10
* _As JavaScript does not yet have static class properties, you will have to add them to the class after it is declared..._
* Previous `static` implementation would have been valid for typescript