### PR TITLE
ci(github-actions): Add pipeline for npm build and publish

### DIFF
--- a/.github/workflows/build-master-publish-npm.yaml
+++ b/.github/workflows/build-master-publish-npm.yaml
@@ -18,7 +18,8 @@ jobs:
         run: npm ci
         id: npm_ci
 
+      # TODO: Remove --access restricted --dry-run once testing is complete.
       # npm publish
       - name: npm_publish
-        run: npm publish
+        run: npm publish --access restricted --dry-run
         id: npm_publish


### PR DESCRIPTION
Requested per https://smartbear.atlassian.net/browse/OP-10666 

This adds a new github-actions pipeline to build and publish the cli npm package. I am on a call with the swaggerhub-cli team now.