### PR TITLE
Reorder pipe

### DIFF
--- a/src/hooks/setup-config.js
+++ b/src/hooks/setup-config.js
@@ -17,7 +17,7 @@ const setAsGlobalUserAgent = ({ userAgent, name, ...rest }) => {
 }
 
 const SetupConfig = async ({ config: defaults }) => (
-  pipe(defaults)(setAsGlobalUserAgent, createConfigPath, setAsGlobalPath, initConfig)
+  pipe(setAsGlobalUserAgent, createConfigPath, setAsGlobalPath, initConfig)(defaults)
 )
 
 module.exports = SetupConfig

--- a/src/support/http/index.js
+++ b/src/support/http/index.js
@@ -39,5 +39,5 @@ const parseHeaders = options => {
 const request = ({ url, ...options }) => fetch(url, options)
 
 module.exports = options => (
-  pipe(options)(parseQuery, parseUrl, parseHeaders, request)
+  pipe(parseQuery, parseUrl, parseHeaders, request)(options)
 )

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,11 +1,13 @@
 const deepExtend = require('deep-extend')
 const jsonTemplate = require('json-templates')
 
-const pipe = val => (...fns) => (
+const pipe = (...fns) => val => (
   fns.reduce((acc, currentFn) => currentFn(acc), val)
 )
 
-const pipeAsync = (...fns) => val => fns.reduce((chain, func) => chain.then(func), Promise.resolve(val))
+const pipeAsync = (...fns) => val => (
+  fns.reduce((chain, func) => chain.then(func), Promise.resolve(val))
+)
 
 const wrapTemplates = templates => Object.keys(templates)
   .reduce((obj, key) => ({

--- a/test/utils/general.test.js
+++ b/test/utils/general.test.js
@@ -1,9 +1,5 @@
 const { expect, test } = require('@oclif/test')
 const { pipe } = require('../../src/utils/general')
-const mock = require('../resources/config')
-const isEqual = require('lodash/isEqual')
-
-const { setConfig, getConfig } = require('../../src/config')
 
 describe('compositions ', () => {
   describe('pipe', () => {
@@ -12,7 +8,7 @@ describe('compositions ', () => {
       const trebleIt = x => x * 3
       const quadrupleIt = x => x * 4
 
-      const output = pipe(1)(doubleIt, trebleIt, quadrupleIt)
+      const output = pipe(doubleIt, trebleIt, quadrupleIt)(1)
       
       expect(output).to.equal(24)
     })


### PR DESCRIPTION
### Standardise codebase

## Proposed Changes

  - Reorder to `pipe` to match `pipeAsync`

