### PR TITLE
Support a way to get version from an api description

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "mocha": true
   },
   "extends": [
-    "eslint:recommended", 
+    "eslint:recommended",
     "plugin:node/recommended",
     "plugin:chai-friendly/recommended",
     "plugin:mocha/recommended"
@@ -63,5 +63,5 @@
         "immutable/no-let": 0
       }
     }
-  ],
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ ARGUMENTS
   FILE  file location of API/Domain to read
 
 OPTIONS
-  -p, --json-pointer=<JSON Pointer>  What to print out, this uses [JSON Pointer](https://tools.ietf.org/html/rfc6901) format. Example '#/info/version'
+  -p, --json-pointer=<JSON Pointer>  What to print out, this uses [JSON Pointer](https://tools.ietf.org/html/rfc6901) format. Example '/info/version'
   -r, --raw  If set, do NOT print quotes around strings
   
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ USAGE
 * [`swaggerhub domain:publish OWNER/DOMAIN_NAME/VERSION`](#swaggerhub-domainpublish-ownerdomain_nameversion)
 * [`swaggerhub domain:unpublish OWNER/DOMAIN_NAME/VERSION`](#swaggerhub-domainunpublish-ownerdomain_nameversion)
 * [`swaggerhub help [COMMAND]`](#swaggerhub-help-command)
+* [`swaggerhub read`](#swaggerhub-read)
+* [`swaggerhub read:version`](#swaggerhub-readversion)
 
 ## `swaggerhub api:create`
 
@@ -271,6 +273,47 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.0.1/src/commands/help.ts)_
+
+## `swaggerhub read`
+
+Read a local YAML/JSON file and output the contents.
+Typically used to read the "version" of an API definition.
+
+```
+USAGE
+  $ swaggerhub read
+
+OPTIONS
+  -f, --file=file(.yaml|.json)  The file to read in
+  -p, --path=<JSON Pointer>  What to print out (in raw format), this uses [JSON Pointer](https://tools.ietf.org/html/rfc6901) format. Example '#/info/version'
+
+DESCRIPTION
+  ...
+  Reads a local file and outputs the contents.
+  Useful if you add the --path flag to specify what path you wish to output.
+  
+  For more advance json parsing, consider using `swaggerhub` in conjunction with the powerful [JQ cli tool](https://github.com/stedolan/jq)
+```
+
+_See code: [src/commands/read.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.2.8/src/commands/read.js)_
+
+## `swaggerhub read:version`
+
+Describe the command here
+
+```
+USAGE
+  $ swaggerhub read:version
+
+OPTIONS
+  -n, --name=name  name to print
+
+DESCRIPTION
+  ...
+  Extra documentation goes here
+```
+
+_See code: [src/commands/read/version.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.2.8/src/commands/read/version.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -282,17 +282,21 @@ Typically used to read the "version" of an API definition.
 
 ```
 USAGE
-  $ swaggerhub read
+  $ swaggerhub read FILE --json-pointer=<JSON Pointer>
+
+ARGUMENTS
+  FILE  file location of API/Domain to read
 
 OPTIONS
-  -f, --file=file(.yaml|.json)  The file to read in
-  -p, --path=<JSON Pointer>  What to print out (in raw format), this uses [JSON Pointer](https://tools.ietf.org/html/rfc6901) format. Example '#/info/version'
+  -p, --json-pointer=<JSON Pointer>  What to print out, this uses [JSON Pointer](https://tools.ietf.org/html/rfc6901) format. Example '#/info/version'
+  -r, --raw  If set, do NOT print quotes around strings
+  
 
 DESCRIPTION
   ...
   Reads a local file and outputs the contents.
   Useful if you add the --path flag to specify what path you wish to output.
-  
+
   For more advance json parsing, consider using `swaggerhub` in conjunction with the powerful [JQ cli tool](https://github.com/stedolan/jq)
 ```
 
@@ -304,14 +308,14 @@ Describe the command here
 
 ```
 USAGE
-  $ swaggerhub read:version
+  $ swaggerhub read:version FILE
 
-OPTIONS
-  -n, --name=name  name to print
+ARGUMENTS
+  FILE  file location of API/Domain to read
 
 DESCRIPTION
   ...
-  Extra documentation goes here
+  An alias for "read --raw --json-pointer=/info/version"
 ```
 
 _See code: [src/commands/read/version.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.2.8/src/commands/read/version.js)_

--- a/src/commands/read.js
+++ b/src/commands/read.js
@@ -13,14 +13,27 @@ class ReadCommand extends BaseCommand {
     const data = parseDefinition(FILE)
     const jsonPointer = flags['json-pointer']
     const raw = flags.raw
+
+    const stringValue = this.getStringValue({
+      fileName: FILE,
+      jsonPointer,
+      isRaw: raw
+    })
+
+    // So that it doesn't output an extra "\n"
+    process.stdout.write(stringValue)
+  }
+
+  getStringValue({ fileName, jsonPointer, isRaw }) {
+    const data = parseDefinition(fileName)
     const value = getJsonPointer(data, jsonPointer)
 
     if (typeof value === 'undefined')
-      throw new CLIError(errorMsg.failedToFindJsonPointer({ jsonPointer, fileName: FILE }))
+      throw new CLIError(errorMsg.failedToFindJsonPointer({ jsonPointer, fileName }))
 
-    // So that it doesn't output an extra "\n"
-    process.stdout.write(stringifyValue(value, raw))
+    return stringifyValue(value, isRaw)
   }
+
 }
 
 function stringifyValue(value, isRaw=false) {
@@ -36,7 +49,7 @@ function stringifyValue(value, isRaw=false) {
   return `${value}`
 }
 
-ReadCommand.description = `Describe the command here
+ReadCommand.description = `Read local file and output contents
 ...
   Reads a local file and outputs the contents.
   Useful if you add the --path flag to specify what path you wish to output.
@@ -61,7 +74,7 @@ ReadCommand.flags = {
 ReadCommand.args = [{
   name: 'FILE',
   required: true,
-  description: 'file location of API to read'
+  description: 'file location of API/Domain to read'
 }]
 
 ReadCommand.examples = [

--- a/src/commands/read.js
+++ b/src/commands/read.js
@@ -1,0 +1,52 @@
+const { flags } = require('@oclif/command')
+const { CLIError } = require('@oclif/errors')
+const { readFileSync } = require('fs-extra')
+const { parseDefinition } = require('../utils/oas')
+const { getJsonPointer } = require('../utils/general')
+const BaseCommand = require('../support/command/base-command')
+const { errorMsg } = require('../template-strings')
+
+class ReadCommand extends BaseCommand {
+  async run() {
+    const { flags, args } = this.parse(ReadCommand)
+    const { FILE } = args
+    const data = parseDefinition(FILE)
+    const jsonPointer = flags['json-pointer']
+    const value = getJsonPointer(data, jsonPointer)
+
+    if(typeof value === 'undefined')
+      throw new CLIError(errorMsg.failedToFindJsonPointer({ jsonPointer, fileName: FILE }))
+
+    // So that it doesn't output an extra "\n"
+    process.stdout.write(`${value}`)
+  }
+}
+
+ReadCommand.description = `Describe the command here
+...
+  Reads a local file and outputs the contents.
+  Useful if you add the --path flag to specify what path you wish to output.
+
+  For more advance json parsing, consider using \`swaggerhub\` in conjunction with the powerful [JQ cli tool](https://github.com/stedolan/jq)
+`
+
+ReadCommand.flags = {
+  ['json-pointer']: flags.string({
+    char: 'p',
+    description: 'JSON Pointer to filter output by',
+    required: true
+  }),
+  ...BaseCommand.flags
+}
+
+ReadCommand.args = [{
+  name: 'FILE',
+  required: true,
+  description: 'file location of API to read'
+}]
+
+ReadCommand.examples = [
+  'swaggerhub read api.yaml --json-path=/info/version',
+]
+
+module.exports = ReadCommand

--- a/src/commands/read/version.js
+++ b/src/commands/read/version.js
@@ -1,20 +1,35 @@
-const {Command, flags} = require('@oclif/command')
+const {flags} = require('@oclif/command')
+const BaseCommand = require('../../support/command/base-command')
+const ReadCommand = require('../read.js')
 
-class VersionCommand extends Command {
+class VersionCommand extends BaseCommand {
   async run() {
-    const {flags} = this.parse(VersionCommand)
-    const name = flags.name || 'world'
-    this.log(`hello ${name} from /home/josh/projects/swaggerhub-cli/src/commands/read/version.js`)
+    const {args} = this.parse(VersionCommand)
+    return ReadCommand.run([args.FILE, '--raw', '--json-pointer=/info/version'])
   }
 }
 
-VersionCommand.description = `Describe the command here
+VersionCommand.description = `Output /info/version from local file
 ...
-Extra documentation goes here
+Reads a local file and outputs the /info/version.
+
+Is an alias for:  swaggerhub read FILE --raw --json-pointer=/info/version
+See the "read" command.
 `
 
 VersionCommand.flags = {
-  name: flags.string({char: 'n', description: 'name to print'}),
+  ...BaseCommand.flags
 }
+
+VersionCommand.args = [{
+  name: 'FILE',
+  required: true,
+  description: 'file location of API/Domain to read'
+}]
+
+VersionCommand.examples = [
+  'swaggerhub read:version api.yaml',
+]
+
 
 module.exports = VersionCommand

--- a/src/commands/read/version.js
+++ b/src/commands/read/version.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class VersionCommand extends Command {
+  async run() {
+    const {flags} = this.parse(VersionCommand)
+    const name = flags.name || 'world'
+    this.log(`hello ${name} from /home/josh/projects/swaggerhub-cli/src/commands/read/version.js`)
+  }
+}
+
+VersionCommand.description = `Describe the command here
+...
+Extra documentation goes here
+`
+
+VersionCommand.flags = {
+  name: flags.string({char: 'n', description: 'name to print'}),
+}
+
+module.exports = VersionCommand

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -12,7 +12,7 @@ const errorMsg = {
   cannotParseVersion: 'Cannot determine version from file',
 
   noContentField: 'No content field provided',
-  
+
   fileIsEmpty: 'File \'{{fileName}}\' is empty',
 
   fileNotFound: 'File \'{{fileName}}\' not found',
@@ -20,6 +20,8 @@ const errorMsg = {
   upgradePlan: 'You may need to upgrade your current plan.',
 
   unknown: 'Unknown Error',
+
+  failedToFindJsonPointer: "Failed to find JSON Pointer '{{jsonPointer}}' in defintion '{{fileName}}'"
 }
 
 module.exports = wrapTemplates({

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -52,6 +52,7 @@ const getJsonPointer = (obj, jsonPointer) => {
     return obj
   const path = jsonPointerToArray(jsonPointer)
   return getIn(obj, path)
+}
 
 const prettyPrintJSON = str => {
   const result = JSON.parse(str)

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,5 +1,6 @@
 const deepExtend = require('deep-extend')
 const jsonTemplate = require('json-templates')
+const getIn = require('lodash/get')
 
 const pipe = (...fns) => val => (
   fns.reduce((acc, currentFn) => currentFn(acc), val)
@@ -38,6 +39,19 @@ const hasJsonStructure = str => {
   }
 }
 
+const jsonPointerToArray = jsonPointer => jsonPointer.split('/')
+      .slice(1)
+      .map(token => (
+        token
+          .replace('~1', '/')
+          .replace('~0', '~')
+      ))
+
+const getJsonPointer = (obj, jsonPointer) => {
+  const path = jsonPointerToArray(jsonPointer)
+  return getIn(obj, path)
+}
+
 module.exports = {
   hasJsonStructure,
   isError,
@@ -46,5 +60,7 @@ module.exports = {
   wrapTemplates,
   pipe,
   from,
-  pipeAsync
+  pipeAsync,
+  getJsonPointer,
+  jsonPointerToArray,
 }

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -48,6 +48,8 @@ const jsonPointerToArray = jsonPointer => jsonPointer.split('/')
       ))
 
 const getJsonPointer = (obj, jsonPointer) => {
+  if (jsonPointer === '/')
+    return obj
   const path = jsonPointerToArray(jsonPointer)
   return getIn(obj, path)
 }

--- a/src/utils/oas.js
+++ b/src/utils/oas.js
@@ -1,7 +1,7 @@
 const { CLIError } = require('@oclif/errors')
 const { hasJsonStructure } = require('./general')
 const { safeLoad } = require('js-yaml')
-const { existsSync, readFileSync } = require('fs-extra')
+const fse = require('fs-extra')
 const { errorMsg } = require('../template-strings')
 
 const getOasVersion = ({ swagger, openapi }) => {
@@ -19,15 +19,15 @@ const getVersion = definition => {
 }
 
 const parseDefinition = fileName => {
-  if (!existsSync(fileName)) {
+  if (!fse.existsSync(fileName)) {
     throw new CLIError(errorMsg.fileNotFound({ fileName }))
   }
-  const file = readFileSync(fileName)
+  const file = fse.readFileSync(fileName)
   if (file.length === 0) {
     throw new CLIError(errorMsg.fileIsEmpty({ fileName }))
   }
   try {
-    return hasJsonStructure(file) ? JSON.parse(file) : safeLoad(file) 
+    return hasJsonStructure(file) ? JSON.parse(file) : safeLoad(file)
   } catch (e) {
     throw new CLIError(errorMsg.cannotParseDefinition({ fileName, e: JSON.stringify(e) }))
   }

--- a/test/commands/read.test.js
+++ b/test/commands/read.test.js
@@ -8,10 +8,19 @@ describe('read', () => {
   test
     .stdout()
     .stub(fse, 'existsSync', path => path === FAKE_FILE)
-    .stub(fse, 'readFileSync', () => 'one: 1')
+    .stub(fse, 'readFileSync', () => 'one: hello')
     .command(['read', FAKE_FILE, '-p=/one'])
-    .it('should return the value pointed to by the JSON Pointer', ctx => {
-      expect(ctx.stdout).to.equal('1')
+    .it('should return the (string) JSON value pointed to by the JSON Pointer', ctx => {
+      expect(ctx.stdout).to.equal('"hello"')
+    })
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1')
+    .command(['read', FAKE_FILE, '-p=/'])
+    .it('should return the (object) JSON value pointed to by the JSON Pointer', ctx => {
+      expect(ctx.stdout).to.equal('{\n  "one": 1\n}')
     })
 
   test
@@ -52,5 +61,27 @@ describe('read', () => {
     .command(['read', FAKE_FILE, '-p=/three'])
     .catch(err => expect(err.message).to.include('Failed to find JSON Pointer'))
     .it('should output JSON for objects')
+
+  describe('--raw', () => {
+
+    test
+      .stdout()
+      .stub(fse, 'existsSync', path => path === FAKE_FILE)
+      .stub(fse, 'readFileSync', () => 'one: 1.2.3')
+      .command(['read', FAKE_FILE, '-p=/one', '-r'])
+      .it('should output no quotes around value (string)', ctx => {
+        expect(ctx.stdout).to.equal('1.2.3')
+      })
+
+    test
+      .stdout()
+      .stub(fse, 'existsSync', path => path === FAKE_FILE)
+      .stub(fse, 'readFileSync', () => 'one: 1.2.3')
+      .command(['read', FAKE_FILE, '-p=/', '-r'])
+      .it('should output JSON for object values', ctx => {
+        expect(ctx.stdout).to.equal('{\n  "one": "1.2.3"\n}')
+      })
+
+  })
 
 })

--- a/test/commands/read.test.js
+++ b/test/commands/read.test.js
@@ -1,0 +1,56 @@
+const { expect, test } = require('@oclif/test')
+const fse = require('fs-extra')
+
+const FAKE_FILE = '/tmp/test.txt'
+
+describe('read', () => {
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1')
+    .command(['read', FAKE_FILE, '-p=/one'])
+    .it('should return the value pointed to by the JSON Pointer', ctx => {
+      expect(ctx.stdout).to.equal('1')
+    })
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => false)
+    .command(['read', FAKE_FILE, '-p=/one'])
+    .catch(err => expect(err.message).to.include('not found'))
+    .it('should throw error if file does not exist')
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1\n  two: 2')
+    .command(['read', FAKE_FILE, '-p=/one'])
+    .catch(err => expect(err.message).to.include('problem with parsing'))
+    .it('should throw an error if it cannot parse definition')
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1')
+    .command(['read', FAKE_FILE, '-p=/three'])
+    .catch(err => expect(err.message).to.include('Failed to find JSON Pointer'))
+    .it('should throw error if JSON Pointer is not found')
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1')
+    .command(['read', FAKE_FILE, '-p=/three'])
+    .catch(err => expect(err.message).to.include('Failed to find JSON Pointer'))
+    .it('should output JSON for objects')
+
+  test
+    .stdout()
+    .stub(fse, 'existsSync', path => path === FAKE_FILE)
+    .stub(fse, 'readFileSync', () => 'one: 1')
+    .command(['read', FAKE_FILE, '-p=/three'])
+    .catch(err => expect(err.message).to.include('Failed to find JSON Pointer'))
+    .it('should output JSON for objects')
+
+})

--- a/test/commands/read/version.test.js
+++ b/test/commands/read/version.test.js
@@ -1,0 +1,17 @@
+const {expect, test} = require('@oclif/test')
+
+describe('read:version', () => {
+  test
+  .stdout()
+  .command(['read:version'])
+  .it('runs hello', ctx => {
+    expect(ctx.stdout).to.contain('hello world')
+  })
+
+  test
+  .stdout()
+  .command(['read:version', '--name', 'jeff'])
+  .it('runs hello --name jeff', ctx => {
+    expect(ctx.stdout).to.contain('hello jeff')
+  })
+})

--- a/test/commands/read/version.test.js
+++ b/test/commands/read/version.test.js
@@ -1,17 +1,31 @@
 const {expect, test} = require('@oclif/test')
+const fse = require('fs-extra')
+
+const FAKE_FILE = '/tmp/test.txt'
 
 describe('read:version', () => {
+
   test
   .stdout()
-  .command(['read:version'])
-  .it('runs hello', ctx => {
-    expect(ctx.stdout).to.contain('hello world')
+  .stub(fse, 'existsSync', path => path === FAKE_FILE)
+  .stub(fse, 'readFileSync', () => JSON.stringify({
+    info: {
+      version: '1.2.3'
+    }
+  }))
+  .command(['read:version', FAKE_FILE])
+  .it('return the version within the definition (raw)', ctx => {
+    expect(ctx.stdout).to.equal('1.2.3')
   })
 
   test
   .stdout()
-  .command(['read:version', '--name', 'jeff'])
-  .it('runs hello --name jeff', ctx => {
-    expect(ctx.stdout).to.contain('hello jeff')
-  })
+  .stub(fse, 'existsSync', path => path === FAKE_FILE)
+  .stub(fse, 'readFileSync', () => JSON.stringify({
+    info: {}
+  }))
+  .command(['read:version', FAKE_FILE])
+  .catch(err => expect(err.message).to.include('Failed to find JSON Pointer'))
+  .it('should throw an error if the version is missing from the definition')
+
 })

--- a/test/utils/general.test.js
+++ b/test/utils/general.test.js
@@ -1,7 +1,8 @@
 const { expect, test } = require('@oclif/test')
-const { pipe } = require('../../src/utils/general')
+const { pipe, getJsonPointer, jsonPointerToArray } = require('../../src/utils/general')
 
-describe('compositions ', () => {
+describe('utils/general ', () => {
+
   describe('pipe', () => {
     test.it('should pipe (left to right) ouput of 1st function through input of the next', () => {
       const doubleIt = x => x * 2
@@ -9,9 +10,30 @@ describe('compositions ', () => {
       const quadrupleIt = x => x * 4
 
       const output = pipe(doubleIt, trebleIt, quadrupleIt)(1)
-      
+
       expect(output).to.equal(24)
     })
   })
+
+
+  describe('jsonPointerToArray', () => {
+    test.it('should tokenize a JSON Pointer', () => {
+      const output = jsonPointerToArray('/info/version')
+      expect(output).to.eql(['info', 'version'])
+    })
+
+
+    test.it('should handle escaped ~ and /', () => {
+      const output = jsonPointerToArray('/paths/~1foo/get/x-~0')
+      expect(output).to.eql(['paths', '/foo', 'get', 'x-~'])
+    })
+  })
+
+  describe('getJsonPointer', () => {
+    test.it('should return /info/version from json object', () => {
+      const output = getJsonPointer({ info: { version: '1.2.3' } }, '/info/version')
+      expect(output).to.equal('1.2.3')
+    })
+  })
+
 })
-  

--- a/test/utils/general.test.js
+++ b/test/utils/general.test.js
@@ -36,4 +36,17 @@ describe('utils/general ', () => {
     })
   })
 
+
+  describe('getJsonPointer', () => {
+    test.it('should return the root value with path = "/"', () => {
+      const output = getJsonPointer({ info: { version: '1.2.3' } }, '/')
+      expect(output).to.eql({
+        info: {
+          version: '1.2.3'
+        }
+      })
+    })
+  })
+
+
 })

--- a/test/utils/oas.test.js
+++ b/test/utils/oas.test.js
@@ -1,0 +1,42 @@
+const { expect, test } = require('@oclif/test')
+const { parseDefinition } = require('../../src/utils/oas')
+const fse = require('fs-extra')
+
+describe('utils/oas ', () => {
+
+  describe('parseDefinition', () => {
+
+    test
+      .stub(fse, 'existsSync', path => path === '/tmp/test.txt')
+      .do(() => parseDefinition('/path/not/found'))
+      .catch(err => {
+        expect(err.message).to.include('not found')
+        expect(err.message).to.include('path/not/found')
+      })
+      .it('should throw file missing error')
+
+    test
+      .stub(fse, 'existsSync', path => path === '/tmp/test.txt')
+      .stub(fse, 'readFileSync', () => '{"one": 1}')
+      .it('should read in a json file (mocked)', () => {
+        const output = parseDefinition('/tmp/test.txt')
+        expect(output).to.eql({ one: 1 })
+      })
+
+    test
+      .stub(fse, 'existsSync', path => path === '/tmp/test.txt')
+      .stub(fse, 'readFileSync', () => 'one: 1')
+      .it('should read in a yaml file (mocked)', () => {
+        const output = parseDefinition('/tmp/test.txt')
+        expect(output).to.eql({ one: 1 })
+      })
+
+    test
+      .stub(fse, 'existsSync', path => path === '/tmp/test.txt')
+      .stub(fse, 'readFileSync', () => 'one: 1\n  invalid: true')
+      .do(() => parseDefinition('/tmp/test.txt'))
+      .catch(err => expect(err.message).to.include('bad indentation'))
+      .it('should throw "bad indentation" for invalid data')
+
+  })
+})


### PR DESCRIPTION
Adds `read` and the more convenient `read:version` commands

## Proposed Changes
  - `read` command will read a local file and allow you to filter the output via a --json-path flag
  - `read` command also supports `--raw` which will NOT output quotes around strings.
  - `read:version` is an alias for `read --raw --json-pointer=/info/version`

