### PR TITLE
add help message for api:get

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ARGUMENTS
 OPTIONS
   -h, --help      show CLI help
   -j, --json      returns the API in JSON format.
-  -r, --resolved  gets the resolved API definition.
+  -r, --resolved  gets the resolved API definition (supported in v1.25+). 
 
 DESCRIPTION
   When VERSION is not included in the argument, the default version will be returned.

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -18,7 +18,7 @@ class GetAPICommand extends BaseCommand {
 
   logApiDefinition(response) {
     const definition = getResponseContent(response)
-    
+
     this.log(hasJsonStructure(definition)
       ? prettyPrintJSON(definition)
       : definition
@@ -63,7 +63,7 @@ GetAPICommand.examples = [
   'swaggerhub api:get organization/api/1.0.0 --json'
 ]
 
-GetAPICommand.args = [{ 
+GetAPICommand.args = [{
   name: 'OWNER/API_NAME/[VERSION]',
   required: true,
   description: 'SwaggerHub API to fetch'
@@ -76,7 +76,7 @@ GetAPICommand.flags = {
   }),
   resolved: flags.boolean({
     char: 'r',
-    description: 'gets the resolved API definition.'
+    description: 'gets the resolved API definition (supported in v1.25+). '
   }),
   ...BaseCommand.flags
 }


### PR DESCRIPTION
Adds a note in `api:get --help` to show what version of SwaggerHub (since there are OnPrem versions) that `--resolved` is supported. 
