### PR TITLE
feat: Add domain:get command

### DIFF
--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -22,7 +22,7 @@ class GetAPICommand extends BaseCommand {
   }
 
   async ensureVersion([owner, name, version]) {
-    const apiVersion = version || await this.getDefaultVersion([owner, name])
+    const apiVersion = version || await this.getDefaultApiVersion([owner, name])
     return [owner, name, apiVersion]
   }
 

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -9,12 +9,16 @@ class GetAPICommand extends BaseCommand {
   constructor(...props) {
     super(...props)
 
-    this.logDefinition = response => {
-      const definition = getResponseContent(response)
-      this.log(hasJsonStructure(definition)
-        ? prettyPrintJSON(definition)
-        : definition)
-    }
+    this.logApiDefinition = this.logApiDefinition.bind(this)
+  }
+
+  logApiDefinition(response) {
+    const definition = getResponseContent(response)
+
+    this.log(hasJsonStructure(definition)
+      ? prettyPrintJSON(definition)
+      : definition
+    )
   }
 
   async ensureVersion([owner, name, version]) {
@@ -31,7 +35,7 @@ class GetAPICommand extends BaseCommand {
 
     await this.executeHttp({
       execute: () => getApi(pathParams, queryParams, requestType),
-      onResolve: this.logDefinition,
+      onResolve: this.logApiDefinition,
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -9,16 +9,12 @@ class GetAPICommand extends BaseCommand {
   constructor(...props) {
     super(...props)
 
-    this.logApiDefinition = this.logApiDefinition.bind(this)
-  }
-
-  logApiDefinition(response) {
-    const definition = getResponseContent(response)
-
-    this.log(hasJsonStructure(definition)
-      ? prettyPrintJSON(definition)
-      : definition
-    )
+    this.logDefinition = response => {
+      const definition = getResponseContent(response)
+      this.log(hasJsonStructure(definition)
+        ? prettyPrintJSON(definition)
+        : definition)
+    }
   }
 
   async ensureVersion([owner, name, version]) {
@@ -35,7 +31,7 @@ class GetAPICommand extends BaseCommand {
 
     await this.executeHttp({
       execute: () => getApi(pathParams, queryParams, requestType),
-      onResolve: this.logApiDefinition,
+      onResolve: this.logDefinition,
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -8,13 +8,13 @@ const BaseCommand = require('../../support/command/base-command')
 class GetAPICommand extends BaseCommand {
   constructor(...props) {
     super(...props)
+  }
 
-    this.logDefinition = response => {
-      const definition = getResponseContent(response)
-      this.log(hasJsonStructure(definition)
-        ? prettyPrintJSON(definition)
-        : definition)
-    }
+  logDefinition = response => {
+    const definition = getResponseContent(response)
+    this.log(hasJsonStructure(definition)
+      ? prettyPrintJSON(definition)
+      : definition)
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -8,13 +8,13 @@ const BaseCommand = require('../../support/command/base-command')
 class GetAPICommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-  }
 
-  logDefinition = response => {
-    const definition = getResponseContent(response)
-    this.log(hasJsonStructure(definition)
-      ? prettyPrintJSON(definition)
-      : definition)
+    this.logDefinition = response => {
+      const definition = getResponseContent(response)
+      this.log(hasJsonStructure(definition)
+        ? prettyPrintJSON(definition)
+        : definition)
+    }
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -29,7 +29,7 @@ class ValidateCommand extends BaseCommand {
 
   async ensureVersion(apiPath) {
     if (apiPath.split('/').length !== 3) {
-      const version = await this.getDefaultVersion(apiPath.split('/'))
+      const version = await this.getDefaultApiVersion(apiPath.split('/'))
       return `${apiPath}/${version}`
     }
     return apiPath

--- a/src/commands/domain/get.js
+++ b/src/commands/domain/get.js
@@ -8,13 +8,12 @@ const BaseCommand = require('../../support/command/base-command')
 class GetDomainCommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-  }
-
-  logDefinition = response => {
-    const definition = getResponseContent(response)
-    this.log(hasJsonStructure(definition)
-      ? prettyPrintJSON(definition)
-      : definition)
+    this.logDefinition = response => {
+      const definition = getResponseContent(response)
+      this.log(hasJsonStructure(definition)
+        ? prettyPrintJSON(definition)
+        : definition)
+    }
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/commands/domain/get.js
+++ b/src/commands/domain/get.js
@@ -8,12 +8,13 @@ const BaseCommand = require('../../support/command/base-command')
 class GetDomainCommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-    this.logDefinition = response => {
-      const definition = getResponseContent(response)
-      this.log(hasJsonStructure(definition)
-        ? prettyPrintJSON(definition)
-        : definition)
-    }
+  }
+
+  logDefinition = response => {
+    const definition = getResponseContent(response)
+    this.log(hasJsonStructure(definition)
+      ? prettyPrintJSON(definition)
+      : definition)
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/commands/domain/get.js
+++ b/src/commands/domain/get.js
@@ -1,0 +1,67 @@
+const { flags } = require('@oclif/command')
+const { getDomainIdentifierArg, reqType, resolvedParam, splitPathParams } = require('../../support/command/parse-input')
+const { from, hasJsonStructure, prettyPrintJSON } = require('../../utils/general')
+const { getDomain } = require('../../requests/domain')
+const { getResponseContent } = require('../../support/command/handle-response')
+const BaseCommand = require('../../support/command/base-command')
+
+class GetDomainCommand extends BaseCommand {
+  constructor(...props) {
+    super(...props)
+    this.logDefinition = this.logDefinition.bind(this)
+  }
+
+  logDefinition(response) {
+    const definition = getResponseContent(response)
+
+    this.log(hasJsonStructure(definition)
+      ? prettyPrintJSON(definition)
+      : definition
+    )
+  }
+
+  async ensureVersion([owner, name, version]) {
+    const domainVersion = version || await this.getDefaultDomainVersion([owner, name])
+    return [owner, name, domainVersion]
+  }
+
+  async run() {
+    const { args, flags } = this.parse(GetDomainCommand)
+    const requestedDomainPath = getDomainIdentifierArg(args)
+    const requestedPathParams = splitPathParams(requestedDomainPath)
+    const pathParams = await this.ensureVersion(requestedPathParams)
+    const [queryParams, requestType] = from(flags)(resolvedParam, reqType)
+
+    await this.executeHttp({
+      execute: () => getDomain(pathParams, queryParams, requestType),
+      onResolve: this.logDefinition,
+      options: { resolveStatus: [403] }
+    })
+  }
+}
+
+GetDomainCommand.description = `fetches a domain definition
+When VERSION is not included in the argument, the default version will be returned.
+Returns the domain in YAML format by default.
+`
+
+GetDomainCommand.examples = [
+  'swaggerhub domain:get organization/domain',
+  'swaggerhub domain:get organization/domain/1.0.0 --json'
+]
+
+GetDomainCommand.args = [{
+  name: 'OWNER/DOMAIN_NAME/[VERSION]',
+  required: true,
+  description: 'SwaggerHub domain to fetch'
+}]
+
+GetDomainCommand.flags = {
+  json: flags.boolean({
+    char: 'j',
+    description: 'returns the domain in JSON format.'
+  }),
+  ...BaseCommand.flags
+}
+
+module.exports = GetDomainCommand

--- a/src/commands/domain/get.js
+++ b/src/commands/domain/get.js
@@ -8,12 +8,16 @@ const BaseCommand = require('../../support/command/base-command')
 class GetDomainCommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-    this.logDefinition = response => {
-      const definition = getResponseContent(response)
-      this.log(hasJsonStructure(definition)
-        ? prettyPrintJSON(definition)
-        : definition)
-    }
+    this.logDefinition = this.logDefinition.bind(this)
+  }
+
+  logDefinition(response) {
+    const definition = getResponseContent(response)
+
+    this.log(hasJsonStructure(definition)
+      ? prettyPrintJSON(definition)
+      : definition
+    )
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/commands/domain/get.js
+++ b/src/commands/domain/get.js
@@ -8,16 +8,12 @@ const BaseCommand = require('../../support/command/base-command')
 class GetDomainCommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-    this.logDefinition = this.logDefinition.bind(this)
-  }
-
-  logDefinition(response) {
-    const definition = getResponseContent(response)
-
-    this.log(hasJsonStructure(definition)
-      ? prettyPrintJSON(definition)
-      : definition
-    )
+    this.logDefinition = response => {
+      const definition = getResponseContent(response)
+      this.log(hasJsonStructure(definition)
+        ? prettyPrintJSON(definition)
+        : definition)
+    }
   }
 
   async ensureVersion([owner, name, version]) {

--- a/src/requests/api.js
+++ b/src/requests/api.js
@@ -1,28 +1,14 @@
 const config = require('../config')
 const { hasJsonStructure } = require('../utils/general')
 const http = require('../support/http')
+const { getSpec, putSpec } = require('./spec')
 
 const getApi = (pathParams, queryParams, accept = 'json') => {
-  const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
-
-  return http({
-    url: [SWAGGERHUB_URL, 'apis', ...pathParams],
-    auth: SWAGGERHUB_API_KEY,
-    accept: accept,
-    query: queryParams
-  })
+  return getSpec('apis', pathParams, queryParams, accept)
 }
 
 const putApi = ({ pathParams, body }) => {
-  const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
-
-  return http({
-    url: [SWAGGERHUB_URL, 'apis', ...pathParams],
-    auth: SWAGGERHUB_API_KEY,
-    contentType: 'json',
-    method: 'PUT',
-    body
-  })
+  return putSpec('apis', pathParams, body)
 }
 
 const postApi = ({ pathParams, queryParams, body }) => {

--- a/src/requests/api.js
+++ b/src/requests/api.js
@@ -3,13 +3,11 @@ const { hasJsonStructure } = require('../utils/general')
 const http = require('../support/http')
 const { getSpec, putSpec } = require('./spec')
 
-const getApi = (pathParams, queryParams, accept = 'json') => {
-  return getSpec('apis', pathParams, queryParams, accept)
-}
+const getApi = (pathParams, queryParams, accept = 'json') =>
+  getSpec('apis', pathParams, queryParams, accept)
 
-const putApi = ({ pathParams, body }) => {
-  return putSpec('apis', pathParams, body)
-}
+const putApi = ({ pathParams, body }) =>
+  putSpec('apis', pathParams, body)
 
 const postApi = ({ pathParams, queryParams, body }) => {
   const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()

--- a/src/requests/domain.js
+++ b/src/requests/domain.js
@@ -1,12 +1,10 @@
 const { getSpec, putSpec } = require('./spec')
 
-const getDomain = (pathParams, queryParams, accept = 'json') => {
-  return getSpec('domains', pathParams, queryParams, accept)
-}
+const getDomain = (pathParams, queryParams, accept = 'json') =>
+  getSpec('domains', pathParams, queryParams, accept)
 
-const putDomain = ({ pathParams, body }) => {
-  return putSpec('domains', pathParams, body)
-}
+const putDomain = ({ pathParams, body }) =>
+  putSpec('domains', pathParams, body)
 
 module.exports = {
   getDomain,

--- a/src/requests/domain.js
+++ b/src/requests/domain.js
@@ -1,18 +1,14 @@
-const config = require('../config')
-const http = require('../support/http')
+const { getSpec, putSpec } = require('./spec')
+
+const getDomain = (pathParams, queryParams, accept = 'json') => {
+  return getSpec('domains', pathParams, queryParams, accept)
+}
 
 const putDomain = ({ pathParams, body }) => {
-  const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
-
-  return http({
-    url: [SWAGGERHUB_URL, 'domains', ...pathParams],
-    auth: SWAGGERHUB_API_KEY,
-    contentType: 'json',
-    method: 'PUT',
-    body
-  })
+  return putSpec('domains', pathParams, body)
 }
 
 module.exports = {
+  getDomain,
   putDomain
 }

--- a/src/requests/spec.js
+++ b/src/requests/spec.js
@@ -1,0 +1,28 @@
+const config = require('../config')
+const http = require('../support/http')
+
+const getSpec = (specType, pathParams, queryParams, accept) => {
+    const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
+    return http({
+      url: [SWAGGERHUB_URL, specType, ...pathParams],
+      auth: SWAGGERHUB_API_KEY,
+      accept: accept,
+      query: queryParams
+    })
+  }
+
+const putSpec = (specType, pathParams, body) => {
+    const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
+    return http({
+        url: [SWAGGERHUB_URL, specType, ...pathParams],
+        auth: SWAGGERHUB_API_KEY,
+        contentType: 'json',
+        method: 'PUT',
+        body
+    })
+}
+
+module.exports = {
+    getSpec,
+    putSpec
+}

--- a/src/support/command/base-command.js
+++ b/src/support/command/base-command.js
@@ -2,7 +2,8 @@ const { Command, flags } = require('@oclif/command')
 const { capitalise, pipeAsync } = require('../../utils/general')
 const { infoMsg, errorMsg } = require('../../template-strings')
 const { getApi } = require('../../requests/api')
-const { getResponseContent } = require('../../support/command/handle-response')
+const { getDomain } = require('../../requests/domain')
+const { getResponseContent } = require('./handle-response')
 
 const { isURLValid } = require('../../config')
 const {
@@ -44,9 +45,17 @@ class BaseCommand extends Command {
     }
   }
 
-  async getDefaultVersion(identifier) {
+  async getDefaultApiVersion(identifier) {
     return this.executeHttp({
       execute: () => getApi([...identifier, 'settings', 'default']),
+      onResolve: pipeAsync(getResponseContent, versionResponse),
+      options: { resolveStatus: [403] }
+    })
+  }
+
+  async getDefaultDomainVersion(identifier) {
+    return this.executeHttp({
+      execute: () => getDomain([...identifier, 'settings', 'default']),
       onResolve: pipeAsync(getResponseContent, versionResponse),
       options: { resolveStatus: [403] }
     })

--- a/src/support/command/handle-response.js
+++ b/src/support/command/handle-response.js
@@ -20,6 +20,7 @@ const checkForErrors = ({ resolveStatus = [] } = {}) => response => {
 const filterResponseMessaging = response => {
   if (response.status === 403) {
     response.content = response.content.replace(/[.].*::upgrade-link::/, `. ${errorMsg.upgradePlan()}`)
+    response.content = response.content.replace('::public-link::', errorMsg.makePublic())
     return Promise.reject(response)
   }
   return Promise.resolve(response)

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -19,7 +19,9 @@ const errorMsg = {
 
   fileNotFound: 'File \'{{fileName}}\' not found',
 
-  upgradePlan: 'You may need to upgrade your current plan.',
+  upgradePlan: 'You may need to upgrade your current plan',
+
+  makePublic: 'make your definition public',
 
   unknown: 'Unknown Error',
 }

--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -119,7 +119,7 @@ describe('invalid api:create', () => {
     )
     .command(['api:create', 'org/overLimitApi/1.0.0', '--file=test/resources/valid_api.json'])
     .catch(ctx => {
-      expect(ctx.message).to.equal('You have reached the limit of APIs. You may need to upgrade your current plan.')
+      expect(ctx.message).to.equal('You have reached the limit of APIs. You may need to upgrade your current plan')
     })
     .it('runs api:create with org that doesn\'t exist')
 })

--- a/test/commands/domain/get.test.js
+++ b/test/commands/domain/get.test.js
@@ -1,0 +1,129 @@
+const { expect, test } = require('@oclif/test')
+const yaml = require('js-yaml')
+const config = require('../../../src/config')
+
+const validIdentifier = 'org1/domain2/1.0.0'
+const jsonResponse = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Petstore Domain',
+    description: 'Components for Petstore.',
+    version: '1.0.0'
+  }
+}
+
+describe('invalid indentifier on domain:get', () => {
+  test
+    .stdout()
+    .command(['domain:get'])
+    .exit(2)
+    .it('runs domain:get with no indentifier provided')
+
+  test
+    .stdout()
+    .command(['domain:get', 'invalid'])
+    .exit(2)
+    .it('runs domain:get with invalid indentifier provided')
+})
+
+describe('valid identifier on domain:get', () => {
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', { reqheaders: { Accept: 'application/json' } }, domain => domain
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['domain:get', 'org1/domain2/1.0.0', '--json'])
+  .it('runs domain:get --json and returns response in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', { reqheaders: { Accept: 'application/json' } }, domain => domain
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['domain:get', 'org1/domain2/1.0.0', '-j'])
+  .it('runs domain:get -j and returns response in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', { reqheaders: { Accept: 'application/yaml' } }, domain => domain
+    .get(`/${validIdentifier}`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['domain:get', 'org1/domain2/1.0.0'])
+  .it('runs domain:get and returns response in yaml format', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', domain => domain
+    .get('/org1/domain2/settings/default')
+    .reply(200, { version: '1.0.0' })
+  )
+  .nock('https://api.swaggerhub.com/domains', { reqheaders: { Accept: 'application/yaml' } }, domain => domain
+    .get(`/${validIdentifier}`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['domain:get', 'org1/domain2'])
+  .it('runs domain:get to return default domain version in yaml format', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', domain => domain
+    .get('/org1/domain2/settings/default')
+    .reply(200, { version: '1.0.0' })
+  )
+  .nock('https://api.swaggerhub.com/domains', { reqheaders: { Accept: 'application/json' } }, domain => domain
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['domain:get', 'org1/domain2', '-j'])
+  .it('runs domain:get to return default domain version in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
+})
+
+describe('swaggerhub errors on domain:get', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/domains', domain => domain
+      .get(`/${validIdentifier}`)
+      .reply(500, { message: 'Internal Server Error' })
+    )
+    .command(['domain:get', 'org1/domain2/1.0.0'])
+    .exit(2)
+    .it('internal server error returned by SwaggerHub, command fails')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/domains', domain => domain
+      .get(`/${validIdentifier}`)
+      .reply(404, { message: 'Not found' })
+    )
+    .command(['domain:get', 'org1/domain2/1.0.0'])
+    .exit(2)
+    .it('not found returned by SwaggerHub, command fails')
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/domains', domain => domain
+    .get('/org1/domain2/settings/default')
+    .reply(404, { message: 'Unknown domain org1/domain2' })
+  )
+  .command(['domain:get', 'org1/domain2'])
+  .exit(2)
+  .it('not found returned when fetching default version of domain')
+})

--- a/test/commands/domain/get.test.js
+++ b/test/commands/domain/get.test.js
@@ -118,6 +118,20 @@ describe('swaggerhub errors on domain:get', () => {
     .it('not found returned by SwaggerHub, command fails')
 
   test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/domains', domain => domain
+      .get(`/${validIdentifier}`)
+      .reply(403, { message: 'Error: This private API is blocked because you have exceeded your current ' +
+        'plan\'s limits. To access it: either ::upgrade-link:: or ::public-link::.' })
+    )
+    .command(['domain:get', 'org1/domain2/1.0.0'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Error: This private API is blocked because you have exceeded your current ' +
+        'plan\'s limits. You may need to upgrade your current plan or make your definition public.')
+    })
+    .it('not found returned by SwaggerHub, command fails')
+
+  test
   .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
   .nock('https://api.swaggerhub.com/domains', domain => domain
     .get('/org1/domain2/settings/default')


### PR DESCRIPTION
Currently we support retrieving APIs using the `api:get` command, this PR adds the ability to fetch domains using the new `domain:get` command.
Similar to the `api:get` command, the domain is returned in YAML format unless the --json flag is used.