### PR TITLE
feat: Add integration:create

### DIFF
--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -8,7 +8,6 @@ const BaseCommand = require('../../support/command/base-command')
 class GetAPICommand extends BaseCommand {
   constructor(...props) {
     super(...props)
-
     this.logApiDefinition = this.logApiDefinition.bind(this)
   }
 
@@ -21,20 +20,14 @@ class GetAPICommand extends BaseCommand {
     )
   }
 
-  async ensureVersion([owner, name, version]) {
-    const apiVersion = version || await this.getDefaultApiVersion([owner, name])
-    return [owner, name, apiVersion]
-  }
-
   async run() {
     const { args, flags } = this.parse(GetAPICommand)
     const requestedApiPath = getApiIdentifierArg(args)
-    const requestedPathParams = splitPathParams(requestedApiPath)
-    const pathParams = await this.ensureVersion(requestedPathParams)
+    const apiPath = await this.ensureVersion(requestedApiPath)
     const [queryParams, requestType] = from(flags)(resolvedParam, reqType)
 
     await this.executeHttp({
-      execute: () => getApi(pathParams, queryParams, requestType),
+      execute: () => getApi([apiPath], queryParams, requestType),
       onResolve: this.logApiDefinition,
       options: { resolveStatus: [403] }
     })

--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -27,14 +27,6 @@ class ValidateCommand extends BaseCommand {
     this.exit(0)
   }
 
-  async ensureVersion(apiPath) {
-    if (apiPath.split('/').length !== 3) {
-      const version = await this.getDefaultApiVersion(apiPath.split('/'))
-      return `${apiPath}/${version}`
-    }
-    return apiPath
-  }
-
   getValidationResult(apiPath) {
     return this.executeHttp({
       execute: () => getApi([apiPath, 'validation']),

--- a/src/commands/domain/publish.js
+++ b/src/commands/domain/publish.js
@@ -6,17 +6,16 @@ class PublishCommand extends BaseCommand {
   
   async run() {
     const { args } = this.parse(PublishCommand)
-    const requestedDomainPath = getDomainIdentifierArg(args)
-    const [owner, name, version] = splitPathParams(requestedDomainPath)
+    const domainPath = getDomainIdentifierArg(args)
 
     const publish = {
-      pathParams: [owner, name, version, 'settings', 'lifecycle'],
+      pathParams: [domainPath, 'settings', 'lifecycle'],
       body: JSON.stringify({ published: true })
     }
     
     await this.executeHttp({
       execute: () => putDomain(publish), 
-      onResolve: this.logCommandSuccess({ requestedDomainPath }),
+      onResolve: this.logCommandSuccess({ domainPath }),
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/domain/unpublish.js
+++ b/src/commands/domain/unpublish.js
@@ -6,17 +6,16 @@ class UnpublishCommand extends BaseCommand {
   
   async run() {
     const { args } = this.parse(UnpublishCommand)
-    const requestedDomainPath = getDomainIdentifierArg(args)
-    const [owner, name, version] = splitPathParams(requestedDomainPath)
+    const domainPath = getDomainIdentifierArg(args)
 
     const publish = {
-      pathParams: [owner, name, version, 'settings', 'lifecycle'],
+      pathParams: [domainPath, 'settings', 'lifecycle'],
       body: JSON.stringify({ published: false })
     }
     
     await this.executeHttp({
       execute: () => putDomain(publish), 
-      onResolve: this.logCommandSuccess({ requestedDomainPath }),
+      onResolve: this.logCommandSuccess({ domainPath }),
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/integration/create.js
+++ b/src/commands/integration/create.js
@@ -1,0 +1,60 @@
+const { flags } = require('@oclif/command')
+const { readFileSync } = require('fs-extra')
+const { hasJsonStructure } = require('../../utils/general')
+const { postApi } = require('../../requests/api')
+const { getApiIdentifierArg } = require('../../support/command/parse-input')
+const BaseCommand = require('../../support/command/base-command')
+
+class CreateIntegrationCommand extends BaseCommand {
+
+  async run() {
+      const { args, flags } = this.parse(CreateIntegrationCommand)
+
+      const config = readFileSync(flags.file)
+      if (!hasJsonStructure(config)) {
+        return this.throwCommandError()()
+      }
+
+      const requestedApiPath = getApiIdentifierArg(args)
+      const apiPath = await this.ensureVersion(requestedApiPath)
+      await this.createIntegration(apiPath, config)
+  }
+
+  async createIntegration(apiPath, config) {
+    const createRequest = {
+      pathParams: [apiPath, 'integrations'],
+      body: config
+    }
+
+    return this.executeHttp({
+      execute: () => postApi(createRequest), 
+      onResolve: this.logCommandSuccess({ apiPath }),
+      options: {}
+    })
+  }  
+}
+
+CreateIntegrationCommand.description = `creates a new API integation from a JSON configuration file.
+See the documentation for example configuration files.
+`
+
+CreateIntegrationCommand.examples = [
+  'swaggerhub integration:create organization/api/1.0.0 --file config.json'
+]
+
+CreateIntegrationCommand.args = [{ 
+  name: 'OWNER/API_NAME/[VERSION]',
+  required: true,
+  description: 'API where integration will be added'
+}]
+
+CreateIntegrationCommand.flags = {
+  file: flags.string({
+    char: 'f', 
+    description: 'file location of API to create',
+    required: true
+  }),
+  ...BaseCommand.flags
+}
+
+module.exports = CreateIntegrationCommand

--- a/src/commands/integration/create.js
+++ b/src/commands/integration/create.js
@@ -51,6 +51,7 @@ class CreateIntegrationCommand extends BaseCommand {
 }
 
 CreateIntegrationCommand.description = `creates a new API integation from a JSON configuration file.
+When VERSION is not included in the argument, the integration will be added to be default API version.
 See the documentation for example configuration files.
 `
 

--- a/src/commands/integration/create.js
+++ b/src/commands/integration/create.js
@@ -1,26 +1,42 @@
 const { flags } = require('@oclif/command')
-const { readFileSync } = require('fs-extra')
+const { existsSync, readFileSync } = require('fs-extra')
 const { hasJsonStructure } = require('../../utils/general')
 const { postApi } = require('../../requests/api')
 const { getApiIdentifierArg } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const { CLIError } = require('@oclif/errors')
+const { errorMsg } = require('../../template-strings')
 
 class CreateIntegrationCommand extends BaseCommand {
 
   async run() {
       const { args, flags } = this.parse(CreateIntegrationCommand)
-
-      const config = readFileSync(flags.file)
-      if (!hasJsonStructure(config)) {
-        return this.throwCommandError()()
-      }
+      const config = this.readConfigFile(flags.file)
 
       const requestedApiPath = getApiIdentifierArg(args)
       const apiPath = await this.ensureVersion(requestedApiPath)
       await this.createIntegration(apiPath, config)
   }
 
+  readConfigFile(filename) {
+
+    if (!existsSync(filename)) {
+      throw new CLIError(errorMsg.fileNotFound({ filename }))
+    }
+
+    const config = readFileSync(filename)
+    if (config.length === 0) {
+      throw new CLIError(errorMsg.fileIsEmpty({ filename }))
+    }
+
+    if (!hasJsonStructure(config)) {
+      throw new CLIError(errorMsg.invalidConfig())
+    }
+    return config
+  }
+
   async createIntegration(apiPath, config) {
+
     const createRequest = {
       pathParams: [apiPath, 'integrations'],
       body: config

--- a/src/requests/api.js
+++ b/src/requests/api.js
@@ -11,11 +11,10 @@ const putApi = ({ pathParams, body }) =>
 
 const postApi = ({ pathParams, queryParams, body }) => {
   const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
-  const [owner, name] = pathParams
   const isJson = hasJsonStructure(body)
 
   return http({
-    url: [SWAGGERHUB_URL, 'apis', owner, name],
+    url: [SWAGGERHUB_URL, 'apis', ...pathParams],
     auth: SWAGGERHUB_API_KEY,
     contentType: isJson ? 'json' : 'yaml',
     method: 'POST',

--- a/src/support/command/base-command.js
+++ b/src/support/command/base-command.js
@@ -45,6 +45,14 @@ class BaseCommand extends Command {
     }
   }
 
+  async ensureVersion(apiPath) {
+    if (apiPath.split('/').length !== 3) {
+      const version = await this.getDefaultApiVersion(apiPath.split('/'))
+      return `${apiPath}/${version}`
+    }
+    return apiPath
+  }
+
   async getDefaultApiVersion(identifier) {
     return this.executeHttp({
       execute: () => getApi([...identifier, 'settings', 'default']),

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -5,6 +5,8 @@ const errorMsg = {
 
   Configure: 'Failed to write config to {{configFilePath}}',
 
+  IntegrationCreate: 'Invalid configuration file. Please ensure that the file is in JSON format',
+
   argsMustMatchFormat: 'Argument must match {{format}} format',
 
   cannotParseDefinition: 'There was a problem with parsing {{fileName}}. Ensure the definition is valid. {{e}}',

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -5,11 +5,9 @@ const errorMsg = {
 
   Configure: 'Failed to write config to {{configFilePath}}',
 
-  IntegrationCreate: 'Invalid configuration file. Please ensure that the file is in JSON format',
-
   argsMustMatchFormat: 'Argument must match {{format}} format',
 
-  cannotParseDefinition: 'There was a problem with parsing {{fileName}}. Ensure the definition is valid. {{e}}',
+  cannotParseDefinition: 'There was a problem with parsing {{filename}}. Ensure the definition is valid. {{e}}',
 
   cannotParseOasVersion: 'Cannot determine OAS version from file',
 
@@ -17,9 +15,11 @@ const errorMsg = {
 
   noContentField: 'No content field provided',
   
-  fileIsEmpty: 'File \'{{fileName}}\' is empty',
+  fileIsEmpty: 'File \'{{filename}}\' is empty',
 
-  fileNotFound: 'File \'{{fileName}}\' not found',
+  fileNotFound: 'File \'{{filename}}\' not found',
+
+  invalidConfig: 'Invalid configuration file. Please ensure that the file is in JSON format',
 
   upgradePlan: 'You may need to upgrade your current plan',
 

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -17,7 +17,7 @@ const infoMsg = {
 
   DomainUnpublish: 'Unpublished domain {{domainPath}}',
 
-  IntegrationCreate: 'Created integration on API {{apiPath}}',
+  IntegrationCreate: 'Created integration on API \'{{apiPath}}\'',
 
   Configure: 'Saved config to {{configFilePath}}'
 }

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -7,7 +7,7 @@ const infoMsg = {
 
   ApiPublish: 'Published API {{apiPath}}',
 
-  DomainPublish: 'Published domain {{requestedDomainPath}}',
+  DomainPublish: 'Published domain {{domainPath}}',
 
   ApiSetdefault: 'Default version of {{owner}}/{{name}} set to {{version}}',
 
@@ -15,7 +15,9 @@ const infoMsg = {
 
   ApiUnpublish: 'Unpublished API {{apiPath}}',
 
-  DomainUnpublish: 'Unpublished domain {{requestedDomainPath}}',
+  DomainUnpublish: 'Unpublished domain {{domainPath}}',
+
+  IntegrationCreate: 'Created integration on API {{apiPath}}',
 
   Configure: 'Saved config to {{configFilePath}}'
 }

--- a/src/utils/oas.js
+++ b/src/utils/oas.js
@@ -18,18 +18,18 @@ const getVersion = definition => {
   return definition.info.version
 }
 
-const parseDefinition = fileName => {
-  if (!existsSync(fileName)) {
-    throw new CLIError(errorMsg.fileNotFound({ fileName }))
+const parseDefinition = filename => {
+  if (!existsSync(filename)) {
+    throw new CLIError(errorMsg.fileNotFound({ filename }))
   }
-  const file = readFileSync(fileName)
+  const file = readFileSync(filename)
   if (file.length === 0) {
-    throw new CLIError(errorMsg.fileIsEmpty({ fileName }))
+    throw new CLIError(errorMsg.fileIsEmpty({ filename }))
   }
   try {
     return hasJsonStructure(file) ? JSON.parse(file) : safeLoad(file) 
   } catch (e) {
-    throw new CLIError(errorMsg.cannotParseDefinition({ fileName, e: JSON.stringify(e) }))
+    throw new CLIError(errorMsg.cannotParseDefinition({ filename, e: JSON.stringify(e) }))
   }
 }
 

--- a/test/commands/integration/create.test.js
+++ b/test/commands/integration/create.test.js
@@ -1,0 +1,102 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../src/config')
+const validIdentifier = 'org/api/1.0.0'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('valid integration:create', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, integration => integration
+      .post(`/${validIdentifier}/integrations`)
+      .matchHeader('Content-Type', 'application/json')
+      .reply(201)
+    )
+    .stdout()
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/github.json'])
+    .it('runs integration:create with json config file', ctx => {
+      expect(ctx.stdout).to.contains('Created integration on API \'org/api/1.0.0\'')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '1.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, integration => integration
+      .post(`/${validIdentifier}/integrations`)
+      .matchHeader('Content-Type', 'application/json')
+      .reply(201)
+    )
+    .stdout()
+    .command(['integration:create', 'org/api', '--file=test/resources/github.json'])
+    .it('runs integration:create on default API version', ctx => {
+      expect(ctx.stdout).to.contains('Created integration on API \'org/api/1.0.0\'')
+    })
+})
+
+describe('invalid integration:create command issues', () => {
+  test
+    .command(['integration:create'])
+    .exit(2)
+    .it('runs integration:create with no identifier provided')
+
+  test
+    .command(['integration:create', 'invalid'])
+    .exit(2)
+    .it('runs integration:create with no required --file flag')
+
+  test
+    .command(['integration:create', 'owner', '-f=test/resources/github.json'])
+    .exit(2)
+    .it('runs integration:create with org identifier provided')
+})
+
+describe('invalid integration:create file', () => {
+  test
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/missing_file.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/missing_file.json\' not found')
+    })
+    .it('runs integration:create with missing config file')
+
+  test
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/empty.yaml'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/empty.yaml\' is empty')
+    })
+    .it('runs integration:create with empty config file')
+
+  test
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('Invalid configuration file. Please ensure that the file is in JSON format')
+    })
+    .it('runs integration:create with non-JSON config file')
+})
+
+describe('invalid integration:create', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, integration => integration
+      .post(`/${validIdentifier}/integrations`)
+      .reply(409, { message: 'Integration \'Integration Name\' already exists' })
+    )    
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/github.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contains('Integration \'Integration Name\' already exists')
+    })
+    .it('runs integration:create with integration name conflict')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, integration => integration
+      .post(`/${validIdentifier}/integrations`)
+      .reply(404, { message: 'Unknown API org/api/1.0.0' })
+    )
+    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/github.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Unknown API org/api/1.0.0')
+    })
+    .it('runs integration:create with an API that doesn\'t exist')
+})

--- a/test/resources/github.json
+++ b/test/resources/github.json
@@ -1,0 +1,13 @@
+{
+    "name": "GitHub Integration Name",
+    "configType": "GITHUB",
+    "owner": "owner",
+    "token": "0123456789abcdeffedcba9876543210",
+    "repository": "pet-store-test",
+    "syncMethod": "Basic Sync",
+    "branch": "CLI_Test",
+    "target": "YAML (Unresolved)",
+    "outputFolder": "yaml-resolved",
+    "outputFile": "swagger.yaml",
+    "enabled": true
+}


### PR DESCRIPTION
Adding feature to add API integrations. Will follow up with example configuration files and documentation.
Format of the command is: `swaggerhub integration:create org/api/version --file config.json`