### PR TITLE
Update help for file flag

### DIFF
--- a/src/commands/integration/create.js
+++ b/src/commands/integration/create.js
@@ -68,7 +68,7 @@ CreateIntegrationCommand.args = [{
 CreateIntegrationCommand.flags = {
   file: flags.string({
     char: 'f', 
-    description: 'file location of API to create',
+    description: 'location of integration configuration file',
     required: true
   }),
   ...BaseCommand.flags


### PR DESCRIPTION
Updating the help description for the integration:create file flag which was incorrect.