### PR TITLE
fix: Do not change visibility when flag is not provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,5 @@ dist
 .yarn/build-state.yml
 .pnp.*
 
-.idea
+# IntelliJ IDEA Project Configuration
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ dist
 .yarn/build-state.yml
 .pnp.*
 
+.idea

--- a/src/commands/api/get.js
+++ b/src/commands/api/get.js
@@ -1,5 +1,5 @@
 const { flags } = require('@oclif/command')
-const { getApiIdentifierArg, reqType, resolvedParam, splitPathParams } = require('../../support/command/parse-input')
+const { getApiIdentifierArg, reqType, resolvedParam } = require('../../support/command/parse-input')
 const { from, hasJsonStructure, prettyPrintJSON } = require('../../utils/general')
 const { getApi } = require('../../requests/api')
 const { getResponseContent } = require('../../support/command/handle-response')

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -20,7 +20,7 @@ class UpdateAPICommand extends BaseCommand {
 
     return await this.executeHttp({
       execute: () => postApi(updateApiObj),
-      onResolve: this.logCommandSuccess({ owner, name, version, isPrivate, visibility }),
+      onResolve: this.logCommandSuccess({ owner, name, version, visibility }),
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -43,8 +43,10 @@ class UpdateAPICommand extends BaseCommand {
       await this.executeHttp({
         execute: () => getApi([owner, name, apiVersion, 'settings', 'version']),
         onResolve: response => {
-          const isPrivate = flags.visibility ? flags.visibility !== 'public' : getResponseContent(response).private
-          return this.updateApi({ owner, name, version: apiVersion, flags, resolvedIsPrivate: isPrivate })
+          const content = getResponseContent(response)
+          const versionSettings = JSON.parse(content)
+          const isPrivate = flags.visibility ? flags.visibility !== 'public' : versionSettings.private
+          return this.updateApi({ owner, name, version: apiVersion, flags, isPrivate })
         },
         options: { resolveStatus: [403] }
       })

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -39,9 +39,9 @@ class UpdateAPICommand extends BaseCommand {
     const apiVersion = version ? version : defaultVersion
 
     if (flags.file) {
-      await this.handleUpdate(owner, name, apiVersion, flags);
+      await this.handleUpdate(owner, name, apiVersion, flags)
     } else if (flags.visibility) {
-      await this.handleUpdateVisibility(owner, name, apiVersion, flags);
+      await this.handleUpdateVisibility(owner, name, apiVersion, flags)
     }
 
     const apiPathWithVersion = requestedApiPath.split('/').length === 3 ?

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -54,7 +54,7 @@ class UpdateAPICommand extends BaseCommand {
 
   async handleUpdate(owner, name, apiVersion, flags) {
     await this.executeHttp({
-      execute: () => getApi([owner, name, apiVersion, 'settings', 'version']),
+      execute: () => getApi([owner, name, apiVersion, 'settings', 'private']),
       onResolve: response => {
         const content = getResponseContent(response)
         const versionSettings = JSON.parse(content)

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -42,7 +42,9 @@ class UpdateAPICommand extends BaseCommand {
     if (flags.file) {
       await this.executeHttp({
         execute: () => getApi([owner, name, apiVersion]), 
-        onResolve: () => this.updateApi({ owner, name, version: apiVersion, flags, isPrivate, visibility }),
+        onResolve: response => {
+          return this.updateApi({ owner, name, version: apiVersion, flags, isPrivate, visibility })
+        },
         options: { resolveStatus: [403] }
       })
     } else if (flags.visibility) {

--- a/src/support/command/handle-response.js
+++ b/src/support/command/handle-response.js
@@ -19,10 +19,9 @@ const checkForErrors = ({ resolveStatus = [] } = {}) => response => {
 
 const filterResponseMessaging = response => {
   if (response.status === 403) {
-    response.content = response.content.replace(/[.].*::upgrade-link::/, `. ${errorMsg.upgradePlan()}`)
-    response.content = response.content.replace('::public-link::', errorMsg.makePublic())
     return Promise.reject(response)
   }
+
   return Promise.resolve(response)
 }
 

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -14,16 +14,12 @@ const errorMsg = {
   cannotParseVersion: 'Cannot determine version from file',
 
   noContentField: 'No content field provided',
-  
+
   fileIsEmpty: 'File \'{{filename}}\' is empty',
 
   fileNotFound: 'File \'{{filename}}\' not found',
 
   invalidConfig: 'Invalid configuration file. Please ensure that the file is in JSON format',
-
-  upgradePlan: 'You may need to upgrade your current plan',
-
-  makePublic: 'make your definition public',
 
   unknown: 'Unknown Error',
 }

--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -115,11 +115,11 @@ describe('invalid api:create', () => {
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/overLimitApi?version=1.0.0&isPrivate=true&oas=3.0.0')
-      .reply(403, '{"code":403,"message":"You have reached the limit of APIs. To upgrade click here ::upgrade-link::"}')
+      .reply(403, '{"code":403,"message":"You have reached the limit of APIs"}')
     )
     .command(['api:create', 'org/overLimitApi/1.0.0', '--file=test/resources/valid_api.json'])
     .catch(ctx => {
-      expect(ctx.message).to.equal('You have reached the limit of APIs. You may need to upgrade your current plan')
+      expect(ctx.message).to.equal('You have reached the limit of APIs')
     })
     .it('runs api:create with org that doesn\'t exist')
   

--- a/test/commands/api/get.test.js
+++ b/test/commands/api/get.test.js
@@ -1,4 +1,4 @@
-const {expect, test} = require('@oclif/test')
+const { expect, test } = require('@oclif/test')
 const yaml = require('js-yaml')
 const config = require('../../../src/config')
 
@@ -28,142 +28,142 @@ describe('invalid indentifier on apis:get', () => {
 
 describe('valid identifier on api:get', () => {
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
-      .get(`/${validIdentifier}`)
-      .reply(200, jsonResponse)
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2/1.0.0', '--json'])
-    .it('runs api:get --json and returns response in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2/1.0.0', '--json'])
+  .it('runs api:get --json and returns response in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
-      .get(`/${validIdentifier}`)
-      .reply(200, jsonResponse)
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2/1.0.0', '-j'])
-    .it('runs api:get -j and returns response in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2/1.0.0', '-j'])
+  .it('runs api:get -j and returns response in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
-      .get(`/${validIdentifier}`)
-      .reply(200, yaml.dump(jsonResponse))
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2/1.0.0'])
-    .it('runs api:get and returns response in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
+    .get(`/${validIdentifier}`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2/1.0.0'])
+  .it('runs api:get and returns response in yaml format', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', api => api
-      .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
-    )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
-      .get(`/${validIdentifier}`)
-      .reply(200, yaml.dump(jsonResponse))
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2'])
-    .it('runs api:get to return default API version in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', api => api
+    .get('/org1/api2/settings/default')
+    .reply(200, { version: '1.0.0' })
+  )
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
+    .get(`/${validIdentifier}`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2'])
+  .it('runs api:get to return default API version in yaml format', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', api => api
-      .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
-    )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
-      .get(`/${validIdentifier}`)
-      .reply(200, jsonResponse)
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2', '-j'])
-    .it('runs api:get to return default API version in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', api => api
+    .get('/org1/api2/settings/default')
+    .reply(200, { version: '1.0.0' })
+  )
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+    .get(`/${validIdentifier}`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2', '-j'])
+  .it('runs api:get to return default API version in json format', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
-      .get(`/${validIdentifier}?resolved=true`)
-      .reply(200, yaml.dump(jsonResponse))
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2/1.0.0', '--resolved'])
-    .it('runs api:get --resolved to return resolved API definition in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
+    .get(`/${validIdentifier}?resolved=true`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2/1.0.0', '--resolved'])
+  .it('runs api:get --resolved to return resolved API definition in yaml format', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', api => api
-      .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
-    )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
-      .get(`/${validIdentifier}?resolved=true`)
-      .reply(200, yaml.dump(jsonResponse))
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2', '-r'])
-    .it('run api:get -r and returns resolved default API version', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', api => api
+    .get('/org1/api2/settings/default')
+    .reply(200, { version: '1.0.0' })
+  )
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
+    .get(`/${validIdentifier}?resolved=true`)
+    .reply(200, yaml.dump(jsonResponse))
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2', '-r'])
+  .it('run api:get -r and returns resolved default API version', ctx => {
+    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+  })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
-      .get(`/${validIdentifier}?resolved=true`)
-      .reply(200, jsonResponse)
-    )
-    .stdout()
-    .command(['api:get', 'org1/api2/1.0.0', '-jr'])
-    .it('runs api:get -jr to return resolved definition', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-    })
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+    .get(`/${validIdentifier}?resolved=true`)
+    .reply(200, jsonResponse)
+  )
+  .stdout()
+  .command(['api:get', 'org1/api2/1.0.0', '-jr'])
+  .it('runs api:get -jr to return resolved definition', ctx => {
+    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+  })
 })
 
 describe('swaggerhub errors on api:get', () => {
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(500, {message: 'Internal Server Error'})
+      .reply(500, { message: 'Internal Server Error' })
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('internal server error returned by SwaggerHub, command fails')
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(404, {message: 'Not found'})
+      .reply(404, { message: 'Not found' })
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('not found returned by SwaggerHub, command fails')
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', api => api
-      .get('/org1/api2/settings/default')
-      .reply(404, {message: 'Unknown API org1/api2'})
-    )
-    .command(['api:get', 'org1/api2'])
-    .exit(2)
-    .it('not found returned when fetching default version of API')
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+  .nock('https://api.swaggerhub.com/apis', api => api
+    .get('/org1/api2/settings/default')
+    .reply(404, { message: 'Unknown API org1/api2' })
+  )
+  .command(['api:get', 'org1/api2'])
+  .exit(2)
+  .it('not found returned when fetching default version of API')
 })

--- a/test/commands/api/get.test.js
+++ b/test/commands/api/get.test.js
@@ -12,18 +12,18 @@ const jsonResponse = {
   title: 'Swagger Petstore'
 }
 
-describe('invalid indentifier on apis:get', () => {
+describe('invalid identifier on apis:get', () => {
   test
     .stdout()
     .command(['api:get'])
     .exit(2)
-    .it('runs api:get with no indentifier provided')
+    .it('runs api:get with no identifier provided')
 
   test
     .stdout()
     .command(['api:get', 'invalid'])
     .exit(2)
-    .it('runs api:get with invalid indentifier provided')
+    .it('runs api:get with invalid identifier provided')
 })
 
 describe('valid identifier on api:get', () => {

--- a/test/commands/api/get.test.js
+++ b/test/commands/api/get.test.js
@@ -1,4 +1,4 @@
-const { expect, test } = require('@oclif/test')
+const {expect, test} = require('@oclif/test')
 const yaml = require('js-yaml')
 const config = require('../../../src/config')
 
@@ -28,142 +28,142 @@ describe('invalid indentifier on apis:get', () => {
 
 describe('valid identifier on api:get', () => {
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${validIdentifier}`)
-    .reply(200, jsonResponse)
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2/1.0.0', '--json'])
-  .it('runs api:get --json and returns response in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+      .get(`/${validIdentifier}`)
+      .reply(200, jsonResponse)
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2/1.0.0', '--json'])
+    .it('runs api:get --json and returns response in json format', ctx => {
+      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${validIdentifier}`)
-    .reply(200, jsonResponse)
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2/1.0.0', '-j'])
-  .it('runs api:get -j and returns response in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+      .get(`/${validIdentifier}`)
+      .reply(200, jsonResponse)
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2/1.0.0', '-j'])
+    .it('runs api:get -j and returns response in json format', ctx => {
+      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
-    .get(`/${validIdentifier}`)
-    .reply(200, yaml.dump(jsonResponse))
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2/1.0.0'])
-  .it('runs api:get and returns response in yaml format', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+      .get(`/${validIdentifier}`)
+      .reply(200, yaml.dump(jsonResponse))
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2/1.0.0'])
+    .it('runs api:get and returns response in yaml format', ctx => {
+      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', api => api
-    .get('/org1/api2/settings/default')
-    .reply(200, { version: '1.0.0' })
-  )
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
-    .get(`/${validIdentifier}`)
-    .reply(200, yaml.dump(jsonResponse))
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2'])
-  .it('runs api:get to return default API version in yaml format', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', api => api
+      .get('/org1/api2/settings/default')
+      .reply(200, {version: '1.0.0'})
+    )
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+      .get(`/${validIdentifier}`)
+      .reply(200, yaml.dump(jsonResponse))
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2'])
+    .it('runs api:get to return default API version in yaml format', ctx => {
+      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', api => api
-    .get('/org1/api2/settings/default')
-    .reply(200, { version: '1.0.0' })
-  )
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${validIdentifier}`)
-    .reply(200, jsonResponse)
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2', '-j'])
-  .it('runs api:get to return default API version in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', api => api
+      .get('/org1/api2/settings/default')
+      .reply(200, {version: '1.0.0'})
+    )
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+      .get(`/${validIdentifier}`)
+      .reply(200, jsonResponse)
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2', '-j'])
+    .it('runs api:get to return default API version in json format', ctx => {
+      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
-    .get(`/${validIdentifier}?resolved=true`)
-    .reply(200, yaml.dump(jsonResponse))
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2/1.0.0', '--resolved'])
-  .it('runs api:get --resolved to return resolved API definition in yaml format', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+      .get(`/${validIdentifier}?resolved=true`)
+      .reply(200, yaml.dump(jsonResponse))
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2/1.0.0', '--resolved'])
+    .it('runs api:get --resolved to return resolved API definition in yaml format', ctx => {
+      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', api => api
-    .get('/org1/api2/settings/default')
-    .reply(200, { version: '1.0.0' })
-  )
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
-    .get(`/${validIdentifier}?resolved=true`)
-    .reply(200, yaml.dump(jsonResponse))
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2', '-r'])
-  .it('run api:get -r and returns resolved default API version', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', api => api
+      .get('/org1/api2/settings/default')
+      .reply(200, {version: '1.0.0'})
+    )
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+      .get(`/${validIdentifier}?resolved=true`)
+      .reply(200, yaml.dump(jsonResponse))
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2', '-r'])
+    .it('run api:get -r and returns resolved default API version', ctx => {
+      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    })
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${validIdentifier}?resolved=true`)
-    .reply(200, jsonResponse)
-  )
-  .stdout()
-  .command(['api:get', 'org1/api2/1.0.0', '-jr'])
-  .it('runs api:get -jr to return resolved definition', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
-  })
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+      .get(`/${validIdentifier}?resolved=true`)
+      .reply(200, jsonResponse)
+    )
+    .stdout()
+    .command(['api:get', 'org1/api2/1.0.0', '-jr'])
+    .it('runs api:get -jr to return resolved definition', ctx => {
+      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    })
 })
 
 describe('swaggerhub errors on api:get', () => {
   test
-    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(500, { message: 'Internal Server Error' })
+      .reply(500, {message: 'Internal Server Error'})
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('internal server error returned by SwaggerHub, command fails')
 
   test
-    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(404, { message: 'Not found' })
+      .reply(404, {message: 'Not found'})
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('not found returned by SwaggerHub, command fails')
 
   test
-  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', api => api
-    .get('/org1/api2/settings/default')
-    .reply(404, { message: 'Unknown API org1/api2' })
-  )
-  .command(['api:get', 'org1/api2'])
-  .exit(2)
-  .it('not found returned when fetching default version of API')
+    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .nock('https://api.swaggerhub.com/apis', api => api
+      .get('/org1/api2/settings/default')
+      .reply(404, {message: 'Unknown API org1/api2'})
+    )
+    .command(['api:get', 'org1/api2'])
+    .exit(2)
+    .it('not found returned when fetching default version of API')
 })

--- a/test/commands/api/get.test.js
+++ b/test/commands/api/get.test.js
@@ -1,4 +1,4 @@
-const {expect, test} = require('@oclif/test')
+const { expect, test } = require('@oclif/test')
 const yaml = require('js-yaml')
 const config = require('../../../src/config')
 
@@ -28,8 +28,8 @@ describe('invalid indentifier on apis:get', () => {
 
 describe('valid identifier on api:get', () => {
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
       .get(`/${validIdentifier}`)
       .reply(200, jsonResponse)
     )
@@ -40,8 +40,8 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
       .get(`/${validIdentifier}`)
       .reply(200, jsonResponse)
     )
@@ -52,8 +52,8 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
       .get(`/${validIdentifier}`)
       .reply(200, yaml.dump(jsonResponse))
     )
@@ -64,12 +64,12 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
+      .reply(200, { version: '1.0.0' })
     )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
       .get(`/${validIdentifier}`)
       .reply(200, yaml.dump(jsonResponse))
     )
@@ -80,12 +80,12 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
+      .reply(200, { version: '1.0.0' })
     )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
       .get(`/${validIdentifier}`)
       .reply(200, jsonResponse)
     )
@@ -96,8 +96,8 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
       .get(`/${validIdentifier}?resolved=true`)
       .reply(200, yaml.dump(jsonResponse))
     )
@@ -108,12 +108,12 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get('/org1/api2/settings/default')
-      .reply(200, {version: '1.0.0'})
+      .reply(200, { version: '1.0.0' })
     )
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/yaml'}}, api => api
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/yaml' } }, api => api
       .get(`/${validIdentifier}?resolved=true`)
       .reply(200, yaml.dump(jsonResponse))
     )
@@ -124,8 +124,8 @@ describe('valid identifier on api:get', () => {
     })
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
-    .nock('https://api.swaggerhub.com/apis', {reqheaders: {Accept: 'application/json'}}, api => api
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
       .get(`/${validIdentifier}?resolved=true`)
       .reply(200, jsonResponse)
     )
@@ -138,30 +138,30 @@ describe('valid identifier on api:get', () => {
 
 describe('swaggerhub errors on api:get', () => {
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(500, {message: 'Internal Server Error'})
+      .reply(500, { message: 'Internal Server Error' })
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('internal server error returned by SwaggerHub, command fails')
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get(`/${validIdentifier}`)
-      .reply(404, {message: 'Not found'})
+      .reply(404, { message: 'Not found' })
     )
     .command(['api:get', 'org1/api2/1.0.0'])
     .exit(2)
     .it('not found returned by SwaggerHub, command fails')
 
   test
-    .stub(config, 'getConfig', () => ({SWAGGERHUB_URL: 'https://api.swaggerhub.com'}))
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
     .nock('https://api.swaggerhub.com/apis', api => api
       .get('/org1/api2/settings/default')
-      .reply(404, {message: 'Unknown API org1/api2'})
+      .reply(404, { message: 'Unknown API org1/api2' })
     )
     .command(['api:get', 'org1/api2'])
     .exit(2)

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -70,7 +70,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, '{"private": true}')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -96,7 +96,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, '{"private": true}')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -116,7 +116,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, '{"private": true}')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -152,8 +152,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
-      .reply(200)
+      .get('/org/api/1.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -169,8 +169,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -186,8 +186,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -197,6 +197,23 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility=public'])
 
     .it('runs api:update to set API public', ctx => {
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, '{"private": false}')
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .post('/org/api?version=2.0.0&isPrivate=true')
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility=private'])
+
+    .it('runs api:update to set API private', ctx => {
       expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
     })
 
@@ -239,8 +256,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -261,8 +278,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -282,7 +299,6 @@ describe('valid api:update', () => {
 
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
-
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/settings/default')
       .reply(200, { version: '2.0.0' })
@@ -310,10 +326,9 @@ describe('valid api:update', () => {
 
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
-
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -346,8 +361,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0')
-      .reply(200)
+      .get('/org/api/2.0.0/settings/version')
+      .reply(200, { "private": true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -64,7 +64,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -74,7 +74,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(500, '{"code": 500, "message": "Error"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -84,7 +84,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -98,7 +98,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--publish', '--setdefault'])
@@ -110,7 +110,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -130,7 +130,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -167,7 +167,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/version')
+      .get('/org/api/1.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -184,7 +184,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -201,7 +201,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -218,7 +218,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: false })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -271,7 +271,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -293,7 +293,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -342,7 +342,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -376,7 +376,7 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/version')
+      .get('/org/api/2.0.0/settings/private')
       .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -17,6 +17,13 @@ describe('invalid api:update command issues', () => {
     .it('runs api:update with no required --file flag')
 
   test
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility'])
+    .catch(err => {
+      expect(err.message).to.equal('Flag --visibility expects a value')
+    })
+    .it('runs api:update with no required --visibility flag')
+
+  test
     .command(['api:update', 'owner', '-f=test/resources/valid_api.yaml'])
     .exit(2)
     .it('runs api:update with org identifier provided')

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -24,6 +24,14 @@ describe('invalid api:update command issues', () => {
     .it('runs api:update with no required --visibility flag')
 
   test
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility=unexpected'])
+    .catch(err => {
+      expect(err.message).to.equal('Expected --visibility=unexpected to be one of: public, private\n' +
+        'See more help with --help')
+    })
+    .it('runs api:update with unexpected value for required --visibility flag')
+
+  test
     .command(['api:update', 'owner', '-f=test/resources/valid_api.yaml'])
     .exit(2)
     .it('runs api:update with org identifier provided')

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -37,7 +37,7 @@ describe('invalid api:update file issues', () => {
     })
     .it('runs api:update with incorrectly formatted file')
 
-    test
+  test
     .command(['api:update', 'org/api', '--file=test/resources/missing_version.yaml'])
     .catch(ctx => {
       expect(ctx.message).to.contain('Cannot determine version from file')
@@ -49,7 +49,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
+      .get('/org/api/1.0.0/settings/version')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -59,7 +59,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
+      .get('/org/api/1.0.0/settings/version')
       .reply(500, '{"code": 500, "message": "Error"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -69,8 +69,8 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
-      .reply(200)
+      .get('/org/api/1.0.0/settings/version')
+      .reply(200, '{"private": true}')
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -83,7 +83,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
+      .get('/org/api/1.0.0/settings/version')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--publish', '--setdefault'])
@@ -95,8 +95,8 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
-      .reply(200)
+      .get('/org/api/1.0.0/settings/version')
+      .reply(200, '{"private": true}')
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -115,8 +115,8 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0')
-      .reply(200)
+      .get('/org/api/1.0.0/settings/version')
+      .reply(200, '{"private": true}')
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -200,43 +200,43 @@ describe('valid api:update', () => {
       expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
     })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
 
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/settings/default')
-        .reply(200, { version: '2.0.0' })
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/private', { private: false })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api', '--visibility=public'])
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api', '--visibility=public'])
 
-      .it('runs api:update to set API public without a version arg', ctx => {
-        expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
-      })
+    .it('runs api:update to set API public without a version arg', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
+    })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
 
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/settings/default')
-        .reply(200, { version: '2.0.0' })
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/private', { private: false })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api/2.0.0', '--visibility=public'])
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--visibility=public'])
 
-      .it('runs api:update to set API public', ctx => {
-        expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
-      })
+    .it('runs api:update to set API public', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
+    })
 
-    test
+  test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0')
@@ -258,7 +258,7 @@ describe('valid api:update', () => {
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
     })
 
-    test
+  test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0')
@@ -280,127 +280,127 @@ describe('valid api:update', () => {
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
 
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/settings/default')
-        .reply(200, { version: '2.0.0' })
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/private', { private: false })
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/settings/default', { version: '2.0.0' })
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/lifecycle', { published: true })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--publish', '--setdefault'])
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--publish', '--setdefault'])
 
-      .it('runs api:update to set API public, publish API, and set the default version', ctx => {
-        expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
-        expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-        expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
-      })
+    .it('runs api:update to set API public, publish API, and set the default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
 
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/2.0.0')
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .post('/org/api?version=2.0.0&isPrivate=false')
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/settings/default', { version: '2.0.0' })
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/lifecycle', { published: true })
-        .reply(200)
-      )
-      .stdout()
-      .command([
-        'api:update',
-        'org/api',
-        '-f=test/resources/valid_api.json',
-        '--visibility=public',
-        '--publish',
-        '--setdefault'
-      ])
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/2.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .post('/org/api?version=2.0.0&isPrivate=false')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command([
+      'api:update',
+      'org/api',
+      '-f=test/resources/valid_api.json',
+      '--visibility=public',
+      '--publish',
+      '--setdefault'
+    ])
 
-      .it('runs api:update to set API public, publish API, and set the default version with file flag', ctx => {
-        expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
-        expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-        expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
-      })
+    .it('runs api:update to set API public, publish API, and set the default version with file flag', ctx => {
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/2.0.0')
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .post('/org/api?version=2.0.0&isPrivate=true')
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/lifecycle', { published: true })
-        .reply(200)
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/settings/default', { version: '2.0.0' })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--publish'])
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/2.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .post('/org/api?version=2.0.0&isPrivate=true')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--publish'])
 
-      .it('runs api:update to publish API and set default version', ctx => {
-        expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to private')
-        expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-        expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
-      })
+    .it('runs api:update to publish API and set default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to private')
+      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/settings/default')
-        .reply(200, { version: '2.0.0' })
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/2.0.0/settings/lifecycle', { published: true })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api/2.0.0', '--publish'])
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--publish'])
 
-      .it('runs api:update to publish API', ctx => {
-        expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-      })
+    .it('runs api:update to publish API', ctx => {
+      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+    })
 
-    test
-      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
-      .nock(`${shubUrl}/apis`, api => api
-        .get('/org/api/settings/default')
-        .reply(200, { version: '2.0.0' })
-      )
-      .nock(`${shubUrl}/apis`, api => api
-        .put('/org/api/settings/default', { version: '2.0.0' })
-        .reply(200)
-      )
-      .stdout()
-      .command(['api:update', 'org/api/2.0.0', '--setdefault'])
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--setdefault'])
 
-      .it('runs api:update to set default version', ctx => {
-        expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
-      })
+    .it('runs api:update to set default version', ctx => {
+      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    })
 })

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -70,7 +70,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -96,7 +96,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -116,7 +116,7 @@ describe('invalid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -153,7 +153,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/1.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=1.0.0&isPrivate=true')
@@ -170,7 +170,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -187,7 +187,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -204,7 +204,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, '{"private": false}')
+      .reply(200, { private: false })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -257,7 +257,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -279,7 +279,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -328,7 +328,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -362,7 +362,7 @@ describe('valid api:update', () => {
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
       .get('/org/api/2.0.0/settings/version')
-      .reply(200, { "private": true })
+      .reply(200, { private: true })
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')

--- a/test/commands/domain/get.test.js
+++ b/test/commands/domain/get.test.js
@@ -12,18 +12,18 @@ const jsonResponse = {
   }
 }
 
-describe('invalid indentifier on domain:get', () => {
+describe('invalid identifier on domain:get', () => {
   test
     .stdout()
     .command(['domain:get'])
     .exit(2)
-    .it('runs domain:get with no indentifier provided')
+    .it('runs domain:get with no identifier provided')
 
   test
     .stdout()
     .command(['domain:get', 'invalid'])
     .exit(2)
-    .it('runs domain:get with invalid indentifier provided')
+    .it('runs domain:get with invalid identifier provided')
 })
 
 describe('valid identifier on domain:get', () => {

--- a/test/commands/domain/get.test.js
+++ b/test/commands/domain/get.test.js
@@ -122,12 +122,12 @@ describe('swaggerhub errors on domain:get', () => {
     .nock('https://api.swaggerhub.com/domains', domain => domain
       .get(`/${validIdentifier}`)
       .reply(403, { message: 'Error: This private API is blocked because you have exceeded your current ' +
-        'plan\'s limits. To access it: either ::upgrade-link:: or ::public-link::.' })
+        'plan\'s limits' })
     )
     .command(['domain:get', 'org1/domain2/1.0.0'])
     .catch(ctx => {
       expect(ctx.message).to.equal('Error: This private API is blocked because you have exceeded your current ' +
-        'plan\'s limits. You may need to upgrade your current plan or make your definition public.')
+        'plan\'s limits')
     })
     .it('not found returned by SwaggerHub, command fails')
 


### PR DESCRIPTION
This change means that users will not unexpectedly see the privacy setting for a given API version set to private when they update an API using the CLI without specifying the --visibility flag.

@conor-ward @barryadk who else knows about this codebase and could help with review?