### PR TITLE
Update license to SPDX identifer 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "keywords": [
     "oclif"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "src/index.js",
   "oclif": {
     "commands": "./src/commands",


### PR DESCRIPTION
Updating license to the correct Apache 2.0 license identifier: https://spdx.org/licenses/