### PR TITLE
Fixes #174 - API create/update fails when setting publish / default

### DIFF
--- a/src/commands/api/publish.js
+++ b/src/commands/api/publish.js
@@ -1,22 +1,14 @@
-const { putApi } = require('../../requests/api')
-const { getApiIdentifierArg } = require('../../support/command/parse-input')
+const { getApiIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
 
-class PublishCommand extends BaseCommand {
+class PublishCommand extends UpdateCommand {
   async run() {
     const { args } = this.parse(PublishCommand)
     const apiPath = getApiIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(apiPath)
 
-    const publish = {
-      pathParams: [apiPath, 'settings', 'lifecycle'],
-      body: JSON.stringify({ published: true })
-    }
-    
-    await this.executeHttp({
-      execute: () => putApi(publish), 
-      onResolve: this.logCommandSuccess({ apiPath }),
-      options: { resolveStatus: [403] }
-    })
+    await this.updatePublish('apis', owner, name, version)    
   }
 }
 

--- a/src/commands/api/setdefault.js
+++ b/src/commands/api/setdefault.js
@@ -1,24 +1,15 @@
-const { putApi } = require('../../requests/api')
 const { getApiIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
 
-class SetDefaultCommand extends BaseCommand {
+class SetDefaultCommand extends UpdateCommand {
 
   async run() {
     const { args } = this.parse(SetDefaultCommand)
     const apiPath = getApiIdentifierArg(args)
     const [owner, name, version] = splitPathParams(apiPath)
 
-    const setDefault = {
-      pathParams: [owner, name, 'settings', 'default'],
-      body: JSON.stringify({ version })
-    }
-    
-    await this.executeHttp({
-      execute: () => putApi(setDefault), 
-      onResolve: this.logCommandSuccess({ owner, name, version }),
-      options: { resolveStatus: [403] }
-    })
+    await this.updateDefault('apis', owner, name, version)
   }
 }
 

--- a/src/commands/domain/publish.js
+++ b/src/commands/domain/publish.js
@@ -1,23 +1,15 @@
-const { putDomain } = require('../../requests/domain')
 const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
 
-class PublishCommand extends BaseCommand {
+class PublishCommand extends UpdateCommand {
   
   async run() {
     const { args } = this.parse(PublishCommand)
     const domainPath = getDomainIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(domainPath)
 
-    const publish = {
-      pathParams: [domainPath, 'settings', 'lifecycle'],
-      body: JSON.stringify({ published: true })
-    }
-    
-    await this.executeHttp({
-      execute: () => putDomain(publish), 
-      onResolve: this.logCommandSuccess({ domainPath }),
-      options: { resolveStatus: [403] }
-    })
+    await this.updatePublish('domains', owner, name, version)
   }
 }
 

--- a/src/support/command/update-command.js
+++ b/src/support/command/update-command.js
@@ -1,0 +1,36 @@
+const BaseCommand = require('./base-command')
+const { putSpec } = require('../../requests/spec')
+
+class UpdateCommand extends BaseCommand {
+
+  async updatePublish(type, owner, name, version) {
+    const pathParams = [owner, name, version, 'settings', 'lifecycle']
+    const body = JSON.stringify({ published: true })
+
+    await this.executeHttp({
+        execute: () => putSpec(type, pathParams, body), 
+        onResolve: this.setSuccessMessage('published')({ 
+          type: type === 'apis' ? 'API' : 'domain',
+          path: `${owner}/${name}/${version}`
+        }),
+        options: { resolveStatus: [403] }
+    })
+  }
+
+  async updateDefault(type, owner, name, version) {
+    const pathParams = [owner, name, 'settings', 'default']
+    const body = JSON.stringify({ version })
+    
+    await this.executeHttp({
+      execute: () => putSpec(type, pathParams, body), 
+      onResolve: this.setSuccessMessage('setDefault')({
+        owner,
+        name,
+        version
+      }),
+      options: { resolveStatus: [403] }
+    })
+  }
+}
+
+module.exports = UpdateCommand

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -5,11 +5,9 @@ const infoMsg = {
 
   createdApiVersion: 'Created version {{version}} of API \'{{owner}}/{{name}}\'',
 
-  ApiPublish: 'Published API {{apiPath}}',
+  published: 'Published {{type}} {{path}}',
 
-  DomainPublish: 'Published domain {{domainPath}}',
-
-  ApiSetdefault: 'Default version of {{owner}}/{{name}} set to {{version}}',
+  setDefault: 'Default version of {{owner}}/{{name}} set to {{version}}',
 
   ApiUpdate: 'Updated API {{owner}}/{{name}}/{{version}} and visibility is set to {{visibility}}',
 


### PR DESCRIPTION
The issue was caused by the Create / Update commands calling the Publish / SetDefault commands. The BaseCommand (when superclass of Publish/SetDefault) does not get the `this.id` value set, so we attempt to `split` on an undefined variable.
This fix refactors the functions to update the Publish and Default states into an `UpdateCommand`, which the existing Commands now extend (API Create, API Update, API Publish, API Set Default, Domain Publish).
This change removes duplicate code and avoids a Command object calling another Command.

I had some difficulty with naming `UpdateCommand`, since `CreateAPICommand` extends it. I'm open to suggestions but I think it accurately reflects the functions that the class provides.