### PR TITLE
feat: Add integration update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ _See code: [src/commands/integration/list.js](https://github.com/SmartBear/swagg
 
 ## `swaggerhub integration:update`
 
-update the configuration of an API integation.
+update the configuration of an API integration.
 
 ```
 USAGE

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ USAGE
 * [`swaggerhub integration:create OWNER/API_NAME/[VERSION]`](#swaggerhub-integrationcreate)
 * [`swaggerhub integration:get OWNER/API_NAME/VERSION/INTEGRATION_ID`](#swaggerhub-integrationget)
 * [`swaggerhub integration:list OWNER/API_NAME/[VERSION]`](#swaggerhub-integrationlist)
+* [`swaggerhub integration:update OWNER/API_NAME/VERSION/INTEGRATION_ID`](#swaggerhub-integrationupdate)
 * [`swaggerhub plugins`](#swaggerhub-plugins)
 * [`swaggerhub plugins:install PLUGIN...`](#swaggerhub-pluginsinstall-plugin)
 * [`swaggerhub plugins:link PLUGIN`](#swaggerhub-pluginslink-plugin)
@@ -503,6 +504,27 @@ EXAMPLE
 ```
 
 _See code: [src/commands/integration/list.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.2.15/src/commands/integration/list.js)_
+
+## `swaggerhub integration:update`
+
+update the configuration of an API integation.
+
+```
+USAGE
+  $ swaggerhub integration:update OWNER/API_NAME/VERSION/INTEGRATION_ID
+
+ARGUMENTS
+  OWNER/API_NAME/VERSION/INTEGRATION_ID  Integration to update on the given API
+
+OPTIONS
+  -f, --file=file  (required) location of integration configuration file
+  -h, --help       show CLI help
+
+EXAMPLE
+  swaggerhub integration:update organization/api/1.0.0/503c2db6-448a-4678-abcd-0123456789abc --file config.json
+```
+
+_See code: [src/commands/integration/update.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.2.15/src/commands/integration/update.js)_
 
 ## `swaggerhub plugins`
 

--- a/src/commands/integration/create.js
+++ b/src/commands/integration/create.js
@@ -1,42 +1,20 @@
 const { flags } = require('@oclif/command')
-const { existsSync, readFileSync } = require('fs-extra')
-const { hasJsonStructure } = require('../../utils/general')
 const { postApi } = require('../../requests/api')
-const { getApiIdentifierArg } = require('../../support/command/parse-input')
+const { getApiIdentifierArg, readConfigFile } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
-const { CLIError } = require('@oclif/errors')
-const { errorMsg } = require('../../template-strings')
 
 class CreateIntegrationCommand extends BaseCommand {
 
   async run() {
       const { args, flags } = this.parse(CreateIntegrationCommand)
-      const config = this.readConfigFile(flags.file)
+      const config = readConfigFile(flags.file)
 
       const requestedApiPath = getApiIdentifierArg(args)
       const apiPath = await this.ensureVersion(requestedApiPath)
       await this.createIntegration(apiPath, config)
   }
 
-  readConfigFile(filename) {
-
-    if (!existsSync(filename)) {
-      throw new CLIError(errorMsg.fileNotFound({ filename }))
-    }
-
-    const config = readFileSync(filename)
-    if (config.length === 0) {
-      throw new CLIError(errorMsg.fileIsEmpty({ filename }))
-    }
-
-    if (!hasJsonStructure(config)) {
-      throw new CLIError(errorMsg.invalidConfig())
-    }
-    return config
-  }
-
   async createIntegration(apiPath, config) {
-
     const createRequest = {
       pathParams: [apiPath, 'integrations'],
       body: config

--- a/src/commands/integration/update.js
+++ b/src/commands/integration/update.js
@@ -1,0 +1,51 @@
+const { flags } = require('@oclif/command')
+const { putApi } = require('../../requests/api')
+const { getIntegrationIdentifierArg, readConfigFile, splitPathParams } = require('../../support/command/parse-input')
+const BaseCommand = require('../../support/command/base-command')
+
+class UpdateIntegrationCommand extends BaseCommand {
+
+  async run() {
+      const { args, flags } = this.parse(UpdateIntegrationCommand)
+      const integrationPath = getIntegrationIdentifierArg(args)
+      const config = readConfigFile(flags.file)
+      await this.updateIntegration(integrationPath, config)
+  }
+
+  async updateIntegration(integrationPath, config) {
+    const [owner, api, version, integrationId] = splitPathParams(integrationPath)
+    const updateRequest = {
+      pathParams: [owner, api, version, 'integrations', integrationId],
+      body: config
+    }
+
+    return this.executeHttp({
+      execute: () => putApi(updateRequest),
+      onResolve: this.logCommandSuccess({ integrationId, apiPath: `${owner}/${api}/${version}` }),
+      options: {}
+    })
+  }  
+}
+
+UpdateIntegrationCommand.description = 'update the configuration of an API integation.'
+
+UpdateIntegrationCommand.examples = [
+  'swaggerhub integration:update organization/api/1.0.0/503c2db6-448a-4678-abcd-0123456789abc --file config.json'
+]
+
+UpdateIntegrationCommand.args = [{ 
+  name: 'OWNER/API_NAME/VERSION/INTEGRATION_ID',
+  required: true,
+  description: 'Integration to update on the given API'
+}]
+
+UpdateIntegrationCommand.flags = {
+  file: flags.string({
+    char: 'f', 
+    description: 'location of integration configuration file',
+    required: true
+  }),
+  ...BaseCommand.flags
+}
+
+module.exports = UpdateIntegrationCommand

--- a/src/commands/integration/update.js
+++ b/src/commands/integration/update.js
@@ -27,7 +27,7 @@ class UpdateIntegrationCommand extends BaseCommand {
   }  
 }
 
-UpdateIntegrationCommand.description = 'update the configuration of an API integation.'
+UpdateIntegrationCommand.description = 'update the configuration of an API integration.'
 
 UpdateIntegrationCommand.examples = [
   'swaggerhub integration:update organization/api/1.0.0/503c2db6-448a-4678-abcd-0123456789abc --file config.json'

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -1,3 +1,5 @@
+const { existsSync, readFileSync } = require('fs-extra')
+const { hasJsonStructure } = require('../../utils/general')
 const { CLIError } = require('@oclif/errors')
 const { errorMsg } = require('../../template-strings')
 
@@ -40,6 +42,22 @@ const getIntegrationIdentifierArg = args => {
   return identifier
 }
 
+const readConfigFile = filename => {
+  if (!existsSync(filename)) {
+    throw new CLIError(errorMsg.fileNotFound({ filename }))
+  }
+
+  const config = readFileSync(filename)
+  if (config.length === 0) {
+    throw new CLIError(errorMsg.fileIsEmpty({ filename }))
+  }
+
+  if (!hasJsonStructure(config)) {
+    throw new CLIError(errorMsg.invalidConfig())
+  }
+  return config
+}
+
 const splitPathParams = path => path.split('/').filter(Boolean)
 
 const reqType = ({ json }) => json ? 'json' : 'yaml'
@@ -50,6 +68,7 @@ module.exports = {
   getApiIdentifierArg,
   getDomainIdentifierArg,
   getIntegrationIdentifierArg,
+  readConfigFile,
   splitPathParams,
   reqType,
   resolvedParam,

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -23,6 +23,8 @@ const infoMsg = {
 
   IntegrationCreate: 'Created integration on API \'{{apiPath}}\'',
 
+  IntegrationUpdate: 'Updated integration \'{{integrationId}}\' on API \'{{apiPath}}\'',
+
   Configure: 'Saved config to {{configFilePath}}'
 }
 

--- a/test/commands/integration/create.test.js
+++ b/test/commands/integration/create.test.js
@@ -52,29 +52,6 @@ describe('invalid integration:create command issues', () => {
     .it('runs integration:create with org identifier provided')
 })
 
-describe('invalid integration:create file', () => {
-  test
-    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/missing_file.json'])
-    .catch(ctx => {
-      expect(ctx.message).to.contain('File \'test/resources/missing_file.json\' not found')
-    })
-    .it('runs integration:create with missing config file')
-
-  test
-    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/empty.yaml'])
-    .catch(ctx => {
-      expect(ctx.message).to.contain('File \'test/resources/empty.yaml\' is empty')
-    })
-    .it('runs integration:create with empty config file')
-
-  test
-    .command(['integration:create', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
-    .catch(ctx => {
-      expect(ctx.message).to.contain('Invalid configuration file. Please ensure that the file is in JSON format')
-    })
-    .it('runs integration:create with non-JSON config file')
-})
-
 describe('invalid integration:create', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))

--- a/test/commands/integration/update.test.js
+++ b/test/commands/integration/update.test.js
@@ -33,7 +33,7 @@ describe('invalid integration:update command issues', () => {
   test
     .command(['integration:update', 'owner/api/version', '-f=test/resources/github.json'])
     .exit(2)
-    .it('runs integration:update withoout integration identifier provided')
+    .it('runs integration:update without integration identifier provided')
 
     test
     .command(['integration:update', 'owner/api/verion/integration/integrationId', '-f=test/resources/github.json'])

--- a/test/commands/integration/update.test.js
+++ b/test/commands/integration/update.test.js
@@ -1,0 +1,56 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../src/config')
+const apiIdentifier = 'org/api/1.0.0'
+const integrationId = 'integration_id'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('valid integration:update', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, integration => integration
+      .put(`/${apiIdentifier}/integrations/${integrationId}`)
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200)
+    )
+    .stdout()
+    .command(['integration:update', `${apiIdentifier}/${integrationId}`, '--file=test/resources/github.json'])
+    .it('runs integration:update with json config file', ctx =>
+      expect(ctx.stdout).to.equal(`Updated integration \'${integrationId}\' on API \'${apiIdentifier}\'\n`)
+    )
+})
+
+describe('invalid integration:update command issues', () => {
+  test
+    .command(['integration:update'])
+    .exit(2)
+    .it('runs integration:update with no identifier provided')
+
+  test
+    .command(['integration:update', 'owner/api/version/integration'])
+    .exit(2)
+    .it('runs integration:update with no required --file flag')
+
+  test
+    .command(['integration:update', 'owner/api/version', '-f=test/resources/github.json'])
+    .exit(2)
+    .it('runs integration:update withoout integration identifier provided')
+
+    test
+    .command(['integration:update', 'owner/api/verion/integration/integrationId', '-f=test/resources/github.json'])
+    .exit(2)
+    .it('runs integration:update with to many identifiers provided')
+})
+
+describe('invalid integration:update', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, integration => integration
+      .put(`/${apiIdentifier}/integrations/${integrationId}`)
+      .reply(404, { message: `Integration type GITHUB with ID '${integrationId}' not found` })
+    )
+    .command(['integration:update', `${apiIdentifier}/${integrationId}`, '--file=test/resources/github.json'])
+    .catch(ctx =>
+      expect(ctx.message).to.equal(`Integration type GITHUB with ID '${integrationId}' not found`)
+    )
+    .it('runs integration:update with an API / integration that doesn\'t exist')
+})

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -144,7 +144,7 @@ describe('readConfigFile', () => {
   context('valid config file', () =>
     it('should return config content', () => {
       const config = readConfigFile('test/resources/github.json')
-      const configString = new TextDecoder("utf-8").decode(config);
+      const configString = String.fromCharCode.apply(null, config)
       expect(configString).to.contains('GitHub Integration Name')
     })
   )

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -5,6 +5,7 @@ const {
   isValidIdentifier, 
   getApiIdentifierArg, 
   getDomainIdentifierArg,
+  readConfigFile,
   reqType 
 } = require('../../src/support/command/parse-input')
 
@@ -98,44 +99,76 @@ describe('getApiIdentifierArg', () => {
 
 describe('getDomainIdentifierArg', () => {
 
-  context('valid version identifier', () => {
-    it('should be returned', () => {
+  context('valid version identifier', () =>
+    it('should be returned', () =>
       expect(getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/VERSION': 'owner/domain/123' })).to.equal('owner/domain/123')
-    })
-  })
+    )
+  )
 
-  context('valid identifier', () => {
-    it('should be returned', () => {
+  context('valid identifier', () =>
+    it('should be returned', () =>
       expect(getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/[VERSION]': 'owner/domain' }, false)).to.equal('owner/domain')
-    })
-  })
+    )
+  )
 
-  context('invalid identifier', () => {
-    it('should throw an exception', () => {
+  context('invalid identifier', () =>
+    it('should throw an exception', () =>
       expect(() => { getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/VERSION': 'owner/domain/version/extra' })})
         .to.throw(CLIError)
-    })
-  })
+    )
+  )
 
-  context('invalid identifier with space', () => {
-    it('should throw an exception', () => {
+  context('invalid identifier with space', () =>
+    it('should throw an exception', () =>
       expect(() => { getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/VERSION': 'owner/domain name/version' })})
         .to.throw(CLIError)
-    })
-  })
+    )
+  )
 
   context('invalid identifier with space and no version', () => {
-    it('should throw an exception', () => {
+    it('should throw an exception', () =>
       expect(() => { getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/[VERSION]': 'owner/domain name' }, false)})
         .to.throw(CLIError)
-    })
+    )
   })
 
-  context('invalid identifier with version required', () => {
-    it('should throw an exception', () => {
+  context('invalid identifier with version required', () =>
+    it('should throw an exception', () =>
       expect(() => { getDomainIdentifierArg({ 'OWNER/DOMAIN_NAME/VERSION': 'owner/domain' })}).to.throw(CLIError)
+    )
+  )
+})
+
+describe('readConfigFile', () => {
+
+  context('valid config file', () =>
+    it('should return config content', () => {
+      const config = readConfigFile('test/resources/github.json')
+      const configString = new TextDecoder("utf-8").decode(config);
+      expect(configString).to.contains('GitHub Integration Name')
     })
-  })
+  )
+
+  context('config file does not exist', () => 
+    it('should return an error', () =>
+      expect(() => readConfigFile('test/resources/missing_file.json'))
+        .to.throw('File \'test/resources/missing_file.json\' not found')
+    )
+  )
+
+  context('config file is empty', () => 
+    it('should return an error', () =>
+      expect(() => readConfigFile('test/resources/empty.yaml'))
+        .to.throw('File \'test/resources/empty.yaml\' is empty')
+    )
+  )
+
+  context('config file is not in JSON format', () => 
+    it('should return an error', () =>
+      expect(() => readConfigFile('test/resources/invalid_format.yaml'))
+        .to.throw('Invalid configuration file. Please ensure that the file is in JSON format')
+    )
+  )
 })
 
 describe('parseDefinition', () => {


### PR DESCRIPTION
Add the ability to update the configuration of an integration.

Usage:
`swaggerhub integration:update Org/API/1.0.0/21e83842-bf83-43b0-abcd-21fde82d5 --file update.json`


* Moved the readConfigFile() function from the integration:create command into parse-input.js so that it can be reused by the integration:update command.