### PR TITLE
docs: Update topic description for integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       },
       "domain": {
         "description": "this topic supports the management of Domains"
+      },
+      "integration": {
+        "description": "this topic supports the management of Integrations"
       }
     },
     "helpClass": "./src/help"


### PR DESCRIPTION
Currently `swaggerhub integration --help` reads the description of the first command and has that as the description for the topic
```
swaggerhub integration --help
creates a new API integration from a JSON configuration file.
```
This change adds its own separate description
