### PR TITLE
Remove visibility check before update

### DIFF
--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -18,7 +18,7 @@ class UpdateAPICommand extends UpdateCommand {
 
     const updateApiObj = {
       pathParams: [owner, name],
-      queryParams: queryParams,
+      queryParams,
       body: readFileSync(flags.file)
     }
 

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -5,7 +5,6 @@ const { getApiIdentifierArg, splitPathParams } = require('../../support/command/
 const { getVersion, parseDefinition } = require('../../utils/oas')
 const BaseCommand = require('../../support/command/base-command')
 const UpdateCommand = require('../../support/command/update-command')
-const { getResponseContent } = require('../../support/command/handle-response')
 
 class UpdateAPICommand extends UpdateCommand {
 
@@ -17,7 +16,6 @@ class UpdateAPICommand extends UpdateCommand {
       this.logCommandSuccess = this.setSuccessMessage('ApiUpdateVisibility')
     }
 
-    const visibility = queryParams['isPrivate'] ? 'private' : 'public'  
     const updateApiObj = {
       pathParams: [owner, name],
       queryParams: queryParams,
@@ -26,7 +24,7 @@ class UpdateAPICommand extends UpdateCommand {
 
     return await this.executeHttp({
       execute: () => postApi(updateApiObj),
-      onResolve: this.logCommandSuccess({ owner, name, version, visibility }),
+      onResolve: this.logCommandSuccess({ owner, name, version, visibility: flags.visibility }),
       options: { resolveStatus: [403] }
     })
   }

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -13,7 +13,9 @@ const infoMsg = {
 
   setDefault: 'Default version of {{owner}}/{{name}} set to {{version}}',
 
-  ApiUpdate: 'Updated API {{owner}}/{{name}}/{{version}} and visibility is set to {{visibility}}',
+  ApiUpdate: 'Updated API {{owner}}/{{name}}/{{version}}',
+
+  ApiUpdateVisibility: 'Updated API {{owner}}/{{name}}/{{version}} and visibility is set to {{visibility}}',
 
   visibilityUpdate: 'Updated visibility of API {{owner}}/{{name}}/{{version}} to {{visibility}}',
 

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -64,7 +64,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
+      .get('/org/api/1.0.0')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -74,7 +74,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
+      .get('/org/api/1.0.0')
       .reply(500, '{"code": 500, "message": "Error"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
@@ -84,11 +84,11 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/1.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true')
+      .post('/org/api?version=1.0.0')
       .reply(400, '{"code": 400, "error": "Bad Request"}')
     )
     .command(['api:update', `${validIdentifier}`, '--file=test/resources/valid_api.json'])
@@ -98,7 +98,7 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
+      .get('/org/api/1.0.0')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--publish', '--setdefault'])
@@ -110,11 +110,11 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/1.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true')
+      .post('/org/api?version=1.0.0')
       .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -130,11 +130,11 @@ describe('invalid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/1.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true')
+      .post('/org/api?version=1.0.0')
       .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -167,11 +167,11 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/1.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/1.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true')
+      .post('/org/api?version=1.0.0')
       .reply(200)
     )
     .stdout()
@@ -184,11 +184,11 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=true')
+      .post('/org/api?version=2.0.0')
       .reply(200)
     )
     .stdout()
@@ -201,8 +201,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -218,8 +218,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: false })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=true')
@@ -271,11 +271,11 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=true')
+      .post('/org/api?version=2.0.0')
       .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -286,18 +286,18 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--publish'])
 
     .it('runs api:update to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to private')
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
     })
 
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=true')
+      .post('/org/api?version=2.0.0')
       .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -308,7 +308,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault'])
 
     .it('runs api:update to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to private')
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })
 
@@ -342,8 +342,8 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
       .post('/org/api?version=2.0.0&isPrivate=false')
@@ -368,7 +368,7 @@ describe('valid api:update', () => {
     ])
 
     .it('runs api:update to set API public, publish API, and set the default version with file flag', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to public')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })
@@ -376,11 +376,11 @@ describe('valid api:update', () => {
   test
     .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/apis`, api => api
-      .get('/org/api/2.0.0/settings/private')
-      .reply(200, { private: true })
+      .get('/org/api/2.0.0')
+      .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=true')
+      .post('/org/api?version=2.0.0')
       .reply(200)
     )
     .nock(`${shubUrl}/apis`, api => api
@@ -395,7 +395,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--publish'])
 
     .it('runs api:update to publish API and set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to private')
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })


### PR DESCRIPTION
The API visibility endpoint was exposed on the public SwaggerHub API (accessible via API key) in the SwaggerHub on-premise 1.26. (`/apis/{owner}/{api}/{version}/settings/private`)

To support previous versions of SwaggerHub on-premise we can change the API check in `api:update` to fetch the API version rather than its visibility flag.

Previously the `isPrivate` query parameter was always sent when POSTing the update, using the current API's setting when the visibility flag is not passed. The query parameter is only required when changing the visibility so we do not need to fetch the current value.

This will only resolve the case where the API definition is being updated. If the `file` argument is not used then the visibility update endpoint is required and will fail on On-premise versions older than 1.26

Closes #196 