### PR TITLE
Remove trailing slash from the SWAGGERHUB_URL example value for SaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm i -g swaggerhub-cli
 The SwaggerHub CLI can be configured through environment variables or through the [`swaggerhub configure`](#swaggerhub-configure) command. The CLI will look for the following environment variables.
 
 * `SWAGGERHUB_API_KEY` (required) – **Important: keep this key secure.** This is the SwaggerHub API key the CLI will use for authentication. You can find your API key on the [user settings page](https://app.swaggerhub.com/settings/apiKey) in SwaggerHub.
-* `SWAGGERHUB_URL` (optional, default is `https://api.swaggerhub.com/`) – Customers with on-premise installations need to point this to their on-premise API, which is `http(s)://{swaggerhub-host}/v1` (do not append a backslash). 
+* `SWAGGERHUB_URL` (optional, default is `https://api.swaggerhub.com`) – Customers with on-premise installations need to point this to their on-premise API, which is `http(s)://{swaggerhub-host}/v1` (do not append a backslash). 
 
 Alernatively, you can use the `swaggerhub configure` command to create a configuration file for the CLI to use. This command will walk you through the steps to set up the necessary configurations.
 


### PR DESCRIPTION
Changed `https://api.swaggerhub.com/` to `https://api.swaggerhub.com` because the URL with a trailing slash causes the commands to fail with an error

> Error: Please verify that the configured SwaggerHub URL is correct.