### PR TITLE
!chore: Drop node.js 10 support. Add node.js 16 support

### DIFF
--- a/.github/workflows/build-master-push-to-aws.yaml
+++ b/.github/workflows/build-master-push-to-aws.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     # SET UP ENVIRONMENT
     - uses: actions/checkout@v2

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The SwaggerHub CLI enables teams to build automation and workflows around Swagge
 * [Contributing](#contributing)
 <!-- tocstop -->
 # Requirements
-Node.js 10 or later.
+Node.js 12 or later.
 # Installation
 ```sh-session
 $ npm i -g swaggerhub-cli


### PR DESCRIPTION
* Node.js 10 went life of life on 2021-04-30 so we should remove offical support.
* Adding support for Node.js 16 as it is the current release.
* Moving the version in the build workflow to Node.js 12 as this is the current active LTS version.
