### PR TITLE
feat: Allow SwaggerHub running on localhost

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -23,7 +23,8 @@ const setConfig = update => {
 const isURLValid = () => {
   const { SWAGGERHUB_URL } = getConfig()
   return swaggerhubUrlRegex.test(SWAGGERHUB_URL) ||
-   (!SWAGGERHUB_URL.includes('api.swaggerhub.com') && SWAGGERHUB_URL.endsWith('/v1'))
+   (!SWAGGERHUB_URL.includes('api.swaggerhub.com') && SWAGGERHUB_URL.endsWith('/v1')) ||
+   SWAGGERHUB_URL.includes('localhost')
 }
 
 module.exports = {

--- a/test/support/config.test.js
+++ b/test/support/config.test.js
@@ -126,6 +126,11 @@ describe('config ', () => {
     .it('it should return true when using on-premise with /v1 path', () => {
       expect(isURLValid()).to.equal(true)
     })
-  })
 
+    test
+    .do(() => createConfigFileWithConfig({ SWAGGERHUB_URL: 'http://localhost:8088' }))
+    .it('it should return true when using SwaggerHub on localhost', () => {
+      expect(isURLValid()).to.equal(true)
+    })
+  })
 })


### PR DESCRIPTION
When developing with SwaggerHub, it's useful to run services locally (localhost). This change makes it possible to access these services using the CLI without returning an error.
