### PR TITLE
feat: Add domain update and setdefault commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ USAGE
 * [`swaggerhub domain:create OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domaincreate)
 * [`swaggerhub domain:get OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domainget)
 * [`swaggerhub domain:publish OWNER/DOMAIN_NAME/VERSION`](#swaggerhub-domainpublish)
+* [`swaggerhub domain:setdefault OWNER/DOMAIN_NAME/VERSION`](#swaggerhub-domainsetdefault)
 * [`swaggerhub domain:unpublish OWNER/DOMAIN_NAME/VERSION`](#swaggerhub-domainunpublish)
+* [`swaggerhub domain:update OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domainupdate)
 * [`swaggerhub help [COMMAND]`](#swaggerhub-help-command)
 * [`swaggerhub integration:create OWNER/API_NAME/[VERSION]`](#swaggerhub-integrationcreate)
 * [`swaggerhub integration:delete OWNER/API_NAME/VERSION/INTEGRATION_ID`](#swaggerhub-integrationdelete)
@@ -429,6 +431,26 @@ EXAMPLE
 
 _See code: [src/commands/domain/publish.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.4.0/src/commands/domain/publish.js)_
 
+## `swaggerhub domain:setdefault`
+
+set the default version of a domain
+
+```
+USAGE
+  $ swaggerhub domain:setdefault OWNER/DOMAIN_NAME/VERSION
+
+ARGUMENTS
+  OWNER/DOMAIN_NAME/VERSION  domain identifier
+
+OPTIONS
+  -h, --help  show CLI help
+
+EXAMPLE
+  swaggerhub domain:setdefault organization/domain/2.0.0
+```
+
+_See code: [src/commands/domain/setdefault.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.4.0/src/commands/domain/setdefault.js)_
+
 ## `swaggerhub domain:unpublish`
 
 unpublish a domain version
@@ -448,6 +470,40 @@ EXAMPLE
 ```
 
 _See code: [src/commands/domain/unpublish.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.4.0/src/commands/domain/unpublish.js)_
+
+## `swaggerhub domain:update`
+
+update a domain
+
+```
+USAGE
+  $ swaggerhub domain:update OWNER/DOMAIN_NAME/[VERSION]
+
+ARGUMENTS
+  OWNER/DOMAIN_NAME/[VERSION]  domain to update in SwaggerHub
+
+OPTIONS
+  -f, --file=file              file location of domain to update
+  -h, --help                   show CLI help
+  --publish                    sets the domain version as published
+  --setdefault                 sets domain version to be the default
+  --visibility=public|private  visibility of domain in SwaggerHub
+
+DESCRIPTION
+  The domain version from the file will be used unless the version is specified in the command argument.
+  When no file is specified then the default domain version will be updated.
+  The domain visibility can be changed by using visibility flag.
+
+EXAMPLES
+  swaggerhub domain:update organization/domain --file domain.yaml
+  swaggerhub domain:update organization/domain/1.0.0 --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --publish --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --setdefault --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --publish --setdefault --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --visibility=private
+```
+
+_See code: [src/commands/domain/update.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.4.0/src/commands/domain/update.js)_
 
 ## `swaggerhub help [COMMAND]`
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ ARGUMENTS
   OWNER/API_NAME/[VERSION]  API to create in SwaggerHub
 
 OPTIONS
-  -f, --file=file              (required) file location of API to create
-  -h, --help                   show CLI help
-  --publish                    sets the API version as published
-  --setdefault                 sets API version to be the default
-  --visibility=public|private  [default: private] visibility of API in SwaggerHub
+  -f, --file=file                (required) file location of API to create
+  -h, --help                     show CLI help
+  --published=publish|unpublish  [default: unpublish] sets the lifecycle setting of the API version
+  --setdefault                   sets API version to be the default
+  --visibility=public|private    [default: private] visibility of API in SwaggerHub
 
 DESCRIPTION
   The API version from the file will be used unless the version is specified in the command argument.
@@ -155,9 +155,9 @@ DESCRIPTION
 EXAMPLES
   swaggerhub api:create organization/api/1.0.0 --file api.yaml --visibility public
   swaggerhub api:create organization/api --file api.yaml
-  swaggerhub api:create organization/api/1.0.0 --publish --file api.json
+  swaggerhub api:create organization/api/1.0.0 --published=publish --file api.json
   swaggerhub api:create organization/api/1.0.0 --setdefault --file api.json
-  swaggerhub api:create organization/api/1.0.0 --publish --setdefault --file api.json
+  swaggerhub api:create organization/api/1.0.0 --published=publish --setdefault --file api.json
 ```
 
 _See code: [src/commands/api/create.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.4.0/src/commands/api/create.js)_
@@ -284,11 +284,11 @@ ARGUMENTS
   OWNER/API_NAME/[VERSION]  API to update in SwaggerHub
 
 OPTIONS
-  -f, --file=file              file location of API to update
-  -h, --help                   show CLI help
-  --publish                    sets the API version as published
-  --setdefault                 sets API version to be the default
-  --visibility=public|private  visibility of API in SwaggerHub
+  -f, --file=file                file location of API to update
+  -h, --help                     show CLI help
+  --published=publish|unpublish  sets the lifecycle setting of the API version
+  --setdefault                   sets API version to be the default
+  --visibility=public|private    visibility of API in SwaggerHub
 
 DESCRIPTION
   The API version from the file will be used unless the version is specified in the command argument.
@@ -298,9 +298,9 @@ DESCRIPTION
 EXAMPLES
   swaggerhub api:update organization/api --file api.yaml
   swaggerhub api:update organization/api/1.0.0 --file api.json
-  swaggerhub api:update organization/api/1.0.0 --publish --file api.json
+  swaggerhub api:update organization/api/1.0.0 --published=publish --file api.json
   swaggerhub api:update organization/api/1.0.0 --setdefault --file api.json
-  swaggerhub api:update organization/api/1.0.0 --publish --setdefault --file api.json
+  swaggerhub api:update organization/api/1.0.0 --published=unpublish --setdefault --file api.json
   swaggerhub api:update organization/api/1.0.0 --visibility=private
 ```
 
@@ -365,11 +365,11 @@ ARGUMENTS
   OWNER/DOMAIN_NAME/[VERSION]  Domain to create in SwaggerHub
 
 OPTIONS
-  -f, --file=file              (required) file location of domain to create
-  -h, --help                   show CLI help
-  --publish                    sets the domain version as published
-  --setdefault                 sets domain version to be the default
-  --visibility=public|private  [default: private] visibility of domain in SwaggerHub
+  -f, --file=file                (required) file location of domain to create
+  -h, --help                     show CLI help
+  --published=publish|unpublish  [default: unpublish] sets the lifecycle setting of the domain version
+  --setdefault                   sets domain version to be the default
+  --visibility=public|private    [default: private] visibility of domain in SwaggerHub
 
 DESCRIPTION
   The domain version from the file will be used unless the version is specified in the command argument.
@@ -483,11 +483,11 @@ ARGUMENTS
   OWNER/DOMAIN_NAME/[VERSION]  domain to update in SwaggerHub
 
 OPTIONS
-  -f, --file=file              file location of domain to update
-  -h, --help                   show CLI help
-  --publish                    sets the domain version as published
-  --setdefault                 sets domain version to be the default
-  --visibility=public|private  visibility of domain in SwaggerHub
+  -f, --file=file                file location of domain to update
+  -h, --help                     show CLI help
+  --published=publish|unpublish  sets the lifecycle setting of the domain version
+  --setdefault                   sets domain version to be the default
+  --visibility=public|private    visibility of domain in SwaggerHub
 
 DESCRIPTION
   The domain version from the file will be used unless the version is specified in the command argument.
@@ -497,9 +497,9 @@ DESCRIPTION
 EXAMPLES
   swaggerhub domain:update organization/domain --file domain.yaml
   swaggerhub domain:update organization/domain/1.0.0 --file domain.json
-  swaggerhub domain:update organization/domain/1.0.0 --publish --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --published=publish --file domain.json
   swaggerhub domain:update organization/domain/1.0.0 --setdefault --file domain.json
-  swaggerhub domain:update organization/domain/1.0.0 --publish --setdefault --file domain.json
+  swaggerhub domain:update organization/domain/1.0.0 --published=unpublish --setdefault --file domain.json
   swaggerhub domain:update organization/domain/1.0.0 --visibility=private
 ```
 

--- a/src/commands/api/create.js
+++ b/src/commands/api/create.js
@@ -85,7 +85,7 @@ class CreateAPICommand extends UpdateCommand {
       })()
     }
 
-    if (flags.publish) await this.updatePublish(type, owner, name, version)
+    if (flags.published === 'publish') await this.updatePublish(type, owner, name, version, true)
     if (flags.setdefault) await this.updateDefault(type, owner, name, version)
   }
 }
@@ -98,9 +98,9 @@ An error will occur if the API version already exists.
 CreateAPICommand.examples = [
   'swaggerhub api:create organization/api/1.0.0 --file api.yaml --visibility public',
   'swaggerhub api:create organization/api --file api.yaml',
-  'swaggerhub api:create organization/api/1.0.0 --publish --file api.json',
+  'swaggerhub api:create organization/api/1.0.0 --published=publish --file api.json',
   'swaggerhub api:create organization/api/1.0.0 --setdefault --file api.json',
-  'swaggerhub api:create organization/api/1.0.0 --publish --setdefault --file api.json'
+  'swaggerhub api:create organization/api/1.0.0 --published=publish --setdefault --file api.json'
 ]
 
 CreateAPICommand.args = [{ 
@@ -120,9 +120,10 @@ CreateAPICommand.flags = {
     options: ['public', 'private'],
     default: 'private'
   }),
-  publish: flags.boolean({
-    description: 'sets the API version as published',
-    default: false,
+  published: flags.string({
+    description: 'sets the lifecycle setting of the API version',
+    options: ['publish', 'unpublish'],
+    default: 'unpublish',
     required: false,
     dependsOn: ['file']
   }),

--- a/src/commands/api/publish.js
+++ b/src/commands/api/publish.js
@@ -8,7 +8,7 @@ class PublishCommand extends UpdateCommand {
     const apiPath = getApiIdentifierArg(args)
     const [owner, name, version] = splitPathParams(apiPath)
 
-    await this.updatePublish('apis', owner, name, version)    
+    await this.updatePublish('apis', owner, name, version, true)    
   }
 }
 

--- a/src/commands/api/unpublish.js
+++ b/src/commands/api/unpublish.js
@@ -1,23 +1,15 @@
-const { putApi } = require('../../requests/api')
-const { getApiIdentifierArg } = require('../../support/command/parse-input')
+const { getApiIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
 
-class UnpublishCommand extends BaseCommand {
+class UnpublishCommand extends UpdateCommand {
   
   async run() {
     const { args } = this.parse(UnpublishCommand)
     const apiPath = getApiIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(apiPath)
 
-    const unpublish = {
-      pathParams: [apiPath, 'settings', 'lifecycle'],
-      body: JSON.stringify({ published: false })
-    }
-    
-    await this.executeHttp({
-      execute: () => putApi(unpublish), 
-      onResolve: this.logCommandSuccess({ apiPath }),
-      options: { resolveStatus: [403] }
-    })
+    await this.updatePublish('apis', owner, name, version, false)  
   }
 }
 

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -49,7 +49,7 @@ class UpdateAPICommand extends UpdateCommand {
       await this.updateVisibility(type, owner, name, apiVersion, flags.visibility !== 'public')
     }
 
-    if (flags.publish) await this.updatePublish(type, owner, name, apiVersion)
+    if (flags.published) await this.updatePublish(type, owner, name, apiVersion, flags.published === 'publish')
     if (flags.setdefault) await this.updateDefault(type, owner, name, apiVersion)
   }
 
@@ -71,9 +71,9 @@ The API visibility can be changed by using visibility flag.
 UpdateAPICommand.examples = [
   'swaggerhub api:update organization/api --file api.yaml',
   'swaggerhub api:update organization/api/1.0.0 --file api.json',
-  'swaggerhub api:update organization/api/1.0.0 --publish --file api.json',
+  'swaggerhub api:update organization/api/1.0.0 --published=publish --file api.json',
   'swaggerhub api:update organization/api/1.0.0 --setdefault --file api.json',
-  'swaggerhub api:update organization/api/1.0.0 --publish --setdefault --file api.json',
+  'swaggerhub api:update organization/api/1.0.0 --published=unpublish --setdefault --file api.json',
   'swaggerhub api:update organization/api/1.0.0 --visibility=private',
 ]
 
@@ -94,9 +94,10 @@ UpdateAPICommand.flags = {
     description: 'visibility of API in SwaggerHub',
     options: ['public', 'private']
   }),
-  publish: flags.boolean({
-    description: 'sets the API version as published',
-    required: false
+  published: flags.string({
+    description: 'sets the lifecycle setting of the API version',
+    options: ['publish', 'unpublish'],
+    required: false,
   }),
   setdefault: flags.boolean({
     description: 'sets API version to be the default',

--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -1,6 +1,6 @@
 const { flags } = require('@oclif/command')
 const { readFileSync } = require('fs-extra')
-const { getApi, postApi, putApi } = require('../../requests/api')
+const { getApi, postApi } = require('../../requests/api')
 const { getApiIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const { getVersion, parseDefinition } = require('../../utils/oas')
 const BaseCommand = require('../../support/command/base-command')
@@ -46,7 +46,7 @@ class UpdateAPICommand extends UpdateCommand {
     if (flags.file) {
       await this.handleUpdate(owner, name, apiVersion, flags)
     } else if (flags.visibility) {
-      await this.updateVisibility(owner, name, apiVersion, flags)
+      await this.updateVisibility(type, owner, name, apiVersion, flags.visibility !== 'public')
     }
 
     if (flags.publish) await this.updatePublish(type, owner, name, apiVersion)
@@ -57,26 +57,6 @@ class UpdateAPICommand extends UpdateCommand {
     await this.executeHttp({
       execute: () => getApi([owner, name, version]),
       onResolve: () => this.updateApi(owner, name, version, flags),
-      options: { resolveStatus: [403] }
-    })
-  }
-
-  async updateVisibility(owner, name, apiVersion, flags) {
-    const isPrivate = flags.visibility !== 'public'
-    const visibility = isPrivate ? 'private' : 'public'
-    const updateApiObj = {
-      pathParams: [owner, name, apiVersion, 'settings', 'private'],
-      body: JSON.stringify({ private: isPrivate })
-    }
-
-    await this.executeHttp({
-      execute: () => putApi(updateApiObj),
-      onResolve: this.setSuccessMessage('visibilityUpdate')({
-        owner,
-        name,
-        version: apiVersion,
-        visibility
-      }),
       options: { resolveStatus: [403] }
     })
   }

--- a/src/commands/domain/create.js
+++ b/src/commands/domain/create.js
@@ -83,7 +83,7 @@ class CreateDomainCommand extends UpdateCommand {
       })()
     }
 
-    if (flags.publish) await this.updatePublish(type, owner, name, version)
+    if (flags.published === 'publish') await this.updatePublish(type, owner, name, version, true)
     if (flags.setdefault) await this.updateDefault(type, owner, name, version)
   }
 }
@@ -118,9 +118,10 @@ CreateDomainCommand.flags = {
     options: ['public', 'private'],
     default: 'private'
   }),
-  publish: flags.boolean({
-    description: 'sets the domain version as published',
-    default: false,
+  published: flags.string({
+    description: 'sets the lifecycle setting of the domain version',
+    options: ['publish', 'unpublish'],
+    default: 'unpublish',
     required: false,
     dependsOn: ['file']
   }),

--- a/src/commands/domain/publish.js
+++ b/src/commands/domain/publish.js
@@ -9,7 +9,7 @@ class PublishCommand extends UpdateCommand {
     const domainPath = getDomainIdentifierArg(args)
     const [owner, name, version] = splitPathParams(domainPath)
 
-    await this.updatePublish('domains', owner, name, version)
+    await this.updatePublish('domains', owner, name, version, true)
   }
 }
 

--- a/src/commands/domain/setdefault.js
+++ b/src/commands/domain/setdefault.js
@@ -1,0 +1,30 @@
+const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
+const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
+
+class SetDefaultDomainCommand extends UpdateCommand {
+
+  async run() {
+    const { args } = this.parse(SetDefaultDomainCommand)
+    const domainPath = getDomainIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(domainPath)
+
+    await this.updateDefault('domains', owner, name, version)
+  }
+}
+
+SetDefaultDomainCommand.description = 'set the default version of a domain'
+
+SetDefaultDomainCommand.examples = [
+  'swaggerhub domain:setdefault organization/domain/2.0.0'
+]
+
+SetDefaultDomainCommand.args = [{ 
+  name: 'OWNER/DOMAIN_NAME/VERSION',
+  required: true,
+  description: 'domain identifier'
+}]
+
+SetDefaultDomainCommand.flags = BaseCommand.flags
+
+module.exports = SetDefaultDomainCommand

--- a/src/commands/domain/unpublish.js
+++ b/src/commands/domain/unpublish.js
@@ -1,23 +1,15 @@
-const { putDomain } = require('../../requests/domain')
 const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
 const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
 
-class UnpublishCommand extends BaseCommand {
+class UnpublishCommand extends UpdateCommand {
   
   async run() {
     const { args } = this.parse(UnpublishCommand)
     const domainPath = getDomainIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(domainPath)
 
-    const publish = {
-      pathParams: [domainPath, 'settings', 'lifecycle'],
-      body: JSON.stringify({ published: false })
-    }
-    
-    await this.executeHttp({
-      execute: () => putDomain(publish), 
-      onResolve: this.logCommandSuccess({ domainPath }),
-      options: { resolveStatus: [403] }
-    })
+    await this.updatePublish('domains', owner, name, version, false)
   }
 }
 

--- a/src/commands/domain/update.js
+++ b/src/commands/domain/update.js
@@ -1,0 +1,108 @@
+const { flags } = require('@oclif/command')
+const { readFileSync } = require('fs-extra')
+const { getDomain, postDomain } = require('../../requests/domain')
+const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
+const { getVersion, parseDefinition } = require('../../utils/oas')
+const BaseCommand = require('../../support/command/base-command')
+const UpdateCommand = require('../../support/command/update-command')
+
+class UpdateDomainCommand extends UpdateCommand {
+
+  async updateDomain(owner, name, version, flags) {
+    const queryParams = { version }
+
+    if (flags.visibility) {
+      queryParams['isPrivate'] = flags.visibility !== 'public'
+      this.logCommandSuccess = this.setSuccessMessage('DomainUpdateVisibility')
+    }
+
+    const updateDomainObj = {
+      pathParams: [owner, name],
+      queryParams,
+      body: readFileSync(flags.file)
+    }
+
+    return await this.executeHttp({
+      execute: () => postDomain(updateDomainObj),
+      onResolve: this.logCommandSuccess({ owner, name, version, visibility: flags.visibility }),
+      options: { resolveStatus: [403] }
+    })
+  }
+
+  async run() {
+    const { args, flags } = this.parse(UpdateDomainCommand)
+
+    if (!Object.keys(flags).length) {
+      return this.error('No updates specified', { exit: 1 })
+    }
+
+    const definition = flags.file ? parseDefinition(flags.file) : null
+    const domainPath = getDomainIdentifierArg(args)
+    const [owner, name, version] = splitPathParams(domainPath)
+    const defaultVersion = definition ? getVersion(definition) : await this.getDefaultDomainVersion([owner, name])
+    const domainVersion = version ? version : defaultVersion
+    const type = 'domains'
+
+    if (flags.file) {
+      await this.handleUpdate(owner, name, domainVersion, flags)
+    } else if (flags.visibility) {
+      await this.updateVisibility(type, owner, name, domainVersion, flags.visibility !== 'public')
+    }
+
+    if (flags.publish) await this.updatePublish(type, owner, name, domainVersion)
+    if (flags.setdefault) await this.updateDefault(type, owner, name, domainVersion)
+  }
+
+  async handleUpdate(owner, name, version, flags) {
+    await this.executeHttp({
+      execute: () => getDomain([owner, name, version]),
+      onResolve: () => this.updateDomain(owner, name, version, flags),
+      options: { resolveStatus: [403] }
+    })
+  }
+}
+
+UpdateDomainCommand.description = `update a domain
+The domain version from the file will be used unless the version is specified in the command argument.
+When no file is specified then the default domain version will be updated.
+The domain visibility can be changed by using visibility flag.
+`
+
+UpdateDomainCommand.examples = [
+  'swaggerhub domain:update organization/domain --file domain.yaml',
+  'swaggerhub domain:update organization/domain/1.0.0 --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --publish --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --setdefault --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --publish --setdefault --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --visibility=private',
+]
+
+UpdateDomainCommand.args = [{
+  name: 'OWNER/DOMAIN_NAME/[VERSION]',
+  required: true,
+  description: 'domain to update in SwaggerHub'
+}]
+
+UpdateDomainCommand.flags = {
+  file: flags.string({
+    char: 'f',
+    description: 'file location of domain to update',
+    required: false,
+    multiple: false
+  }),
+  visibility: flags.string({
+    description: 'visibility of domain in SwaggerHub',
+    options: ['public', 'private']
+  }),
+  publish: flags.boolean({
+    description: 'sets the domain version as published',
+    required: false
+  }),
+  setdefault: flags.boolean({
+    description: 'sets domain version to be the default',
+    required: false
+  }),
+  ...BaseCommand.flags
+}
+
+module.exports = UpdateDomainCommand

--- a/src/commands/domain/update.js
+++ b/src/commands/domain/update.js
@@ -49,7 +49,7 @@ class UpdateDomainCommand extends UpdateCommand {
       await this.updateVisibility(type, owner, name, domainVersion, flags.visibility !== 'public')
     }
 
-    if (flags.publish) await this.updatePublish(type, owner, name, domainVersion)
+    if (flags.published) await this.updatePublish(type, owner, name, domainVersion, flags.published === 'publish')
     if (flags.setdefault) await this.updateDefault(type, owner, name, domainVersion)
   }
 
@@ -71,9 +71,9 @@ The domain visibility can be changed by using visibility flag.
 UpdateDomainCommand.examples = [
   'swaggerhub domain:update organization/domain --file domain.yaml',
   'swaggerhub domain:update organization/domain/1.0.0 --file domain.json',
-  'swaggerhub domain:update organization/domain/1.0.0 --publish --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --published=publish --file domain.json',
   'swaggerhub domain:update organization/domain/1.0.0 --setdefault --file domain.json',
-  'swaggerhub domain:update organization/domain/1.0.0 --publish --setdefault --file domain.json',
+  'swaggerhub domain:update organization/domain/1.0.0 --published=unpublish --setdefault --file domain.json',
   'swaggerhub domain:update organization/domain/1.0.0 --visibility=private',
 ]
 
@@ -94,8 +94,9 @@ UpdateDomainCommand.flags = {
     description: 'visibility of domain in SwaggerHub',
     options: ['public', 'private']
   }),
-  publish: flags.boolean({
-    description: 'sets the domain version as published',
+  published: flags.string({
+    description: 'sets the lifecycle setting of the domain version',
+    options: ['publish', 'unpublish'],
     required: false
   }),
   setdefault: flags.boolean({

--- a/src/requests/domain.js
+++ b/src/requests/domain.js
@@ -1,16 +1,12 @@
-const { getSpec, putSpec, postSpec } = require('./spec')
+const { getSpec, postSpec } = require('./spec')
 
 const getDomain = (pathParams, queryParams, accept = 'json') =>
   getSpec('domains', pathParams, queryParams, accept)
-
-const putDomain = ({ pathParams, body }) =>
-  putSpec('domains', pathParams, body)
 
 const postDomain = ({ pathParams, queryParams, body }) =>
   postSpec('domains', pathParams, queryParams, body)
 
 module.exports = {
   getDomain,
-  putDomain,
   postDomain
 }

--- a/src/support/command/update-command.js
+++ b/src/support/command/update-command.js
@@ -3,13 +3,14 @@ const { putSpec } = require('../../requests/spec')
 
 class UpdateCommand extends BaseCommand {
 
-  async updatePublish(type, owner, name, version) {
+  async updatePublish(type, owner, name, version, isPublished) {
     const pathParams = [owner, name, version, 'settings', 'lifecycle']
-    const body = JSON.stringify({ published: true })
+    const body = JSON.stringify({ published: isPublished })
+    const successMessage = isPublished ? 'published' : 'unpublished'
 
     await this.executeHttp({
         execute: () => putSpec(type, pathParams, body), 
-        onResolve: this.setSuccessMessage('published')({ 
+        onResolve: this.setSuccessMessage(successMessage)({ 
           type: type === 'apis' ? 'API' : 'domain',
           path: `${owner}/${name}/${version}`
         }),

--- a/src/support/command/update-command.js
+++ b/src/support/command/update-command.js
@@ -31,6 +31,23 @@ class UpdateCommand extends BaseCommand {
       options: { resolveStatus: [403] }
     })
   }
+
+  async updateVisibility(type, owner, name, version, isPrivate) {
+    const visibility = isPrivate ? 'private' : 'public'
+    const pathParams = [owner, name, version, 'settings', 'private']
+    const body = JSON.stringify({ private: isPrivate })
+
+    await this.executeHttp({
+      execute: () => putSpec(type, pathParams, body),
+      onResolve: this.setSuccessMessage('visibilityUpdate')({
+        owner,
+        name,
+        version: version,
+        visibility
+      }),
+      options: { resolveStatus: [403] }
+    })
+  }
 }
 
 module.exports = UpdateCommand

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -19,9 +19,13 @@ const infoMsg = {
 
   ApiUpdate: 'Updated API {{owner}}/{{name}}/{{version}}',
 
+  DomainUpdate: 'Updated domain {{owner}}/{{name}}/{{version}}',
+
   ApiUpdateVisibility: 'Updated API {{owner}}/{{name}}/{{version}} and visibility is set to {{visibility}}',
 
-  visibilityUpdate: 'Updated visibility of API {{owner}}/{{name}}/{{version}} to {{visibility}}',
+  DomainUpdateVisibility: 'Updated domain {{owner}}/{{name}}/{{version}} and visibility is set to {{visibility}}',
+
+  visibilityUpdate: 'Updated visibility of {{owner}}/{{name}}/{{version}} to {{visibility}}',
 
   ApiUnpublish: 'Unpublished API {{apiPath}}',
 

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -15,6 +15,8 @@ const infoMsg = {
 
   published: 'Published {{type}} {{path}}',
 
+  unpublished: 'Unpublished {{type}} {{path}}',
+
   setDefault: 'Default version of {{owner}}/{{name}} set to {{version}}',
 
   ApiUpdate: 'Updated API {{owner}}/{{name}}/{{version}}',

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -247,7 +247,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '--visibility=public'])
 
     .it('runs api:update to set API public without a version arg', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
     })
 
   test
@@ -265,7 +265,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--visibility=private'])
 
     .it('runs api:update to set API private', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to private')
+      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to private')
     })
 
   test
@@ -334,7 +334,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--publish', '--setdefault'])
 
     .it('runs api:update to set API public, publish API, and set the default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of API org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -32,6 +32,14 @@ describe('invalid api:update command issues', () => {
     .it('runs api:update with unexpected value for required --visibility flag')
 
   test
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--published=unexpected'])
+    .catch(err => {
+      expect(err.message).to.equal('Expected --published=unexpected to be one of: publish, unpublish\n' +
+        'See more help with --help')
+    })
+    .it('runs api:update with unexpected value for required --published flag')
+
+  test
     .command(['api:update', 'owner', '-f=test/resources/valid_api.yaml'])
     .exit(2)
     .it('runs api:update with org identifier provided')
@@ -101,7 +109,7 @@ describe('invalid api:update', () => {
       .get('/org/api/1.0.0')
       .reply(404, '{"code": 404, "message": "Unknown API org/api/1.0.0"}')
     )
-    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--publish', '--setdefault'])
+    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
       expect(err.message).to.contains('Unknown API org/api/1.0.0')
     })
@@ -121,7 +129,7 @@ describe('invalid api:update', () => {
       .put('/org/api/1.0.0/settings/lifecycle')
       .reply(500, '{ "code": 500, "message": "An error occurred. Publishing API failed"}')
     )
-    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--setdefault', '--publish'])
+    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--setdefault', '--published=publish'])
     .catch(err => {
       expect(err.message).to.contains('An error occurred. Publishing API failed')
     })
@@ -145,7 +153,7 @@ describe('invalid api:update', () => {
       .put('/org/api/settings/default', { version: '1.0.0' })
       .reply(500, '{ "code": 500, "message": "An error occurred. Setting default version failed"}')
     )
-    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--publish', '--setdefault'])
+    .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
       expect(err.message).to.contains('An error occurred. Setting default version failed')
     })
@@ -283,11 +291,33 @@ describe('valid api:update', () => {
       .reply(200)
     )
     .stdout()
-    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--publish'])
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--published=publish'])
 
     .it('runs api:update to publish API', ctx => {
       expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/2.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .post('/org/api?version=2.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--published=unpublish'])
+
+    .it('runs api:update to publish API', ctx => {
+      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
     })
 
   test
@@ -331,11 +361,38 @@ describe('valid api:update', () => {
       .reply(200)
     )
     .stdout()
-    .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--publish', '--setdefault'])
+    .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--published=publish', '--setdefault'])
 
     .it('runs api:update to set API public, publish API, and set the default version', ctx => {
       expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--published=unpublish', '--setdefault'])
+
+    .it('runs api:update to set API public, publish API, and set the default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
       expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
     })
 
@@ -363,7 +420,7 @@ describe('valid api:update', () => {
       'org/api',
       '-f=test/resources/valid_api.json',
       '--visibility=public',
-      '--publish',
+      '--published=publish',
       '--setdefault'
     ])
 
@@ -392,7 +449,7 @@ describe('valid api:update', () => {
       .reply(200)
     )
     .stdout()
-    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--publish'])
+    .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--published=publish'])
 
     .it('runs api:update to publish API and set default version', ctx => {
       expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
@@ -411,10 +468,27 @@ describe('valid api:update', () => {
       .reply(200)
     )
     .stdout()
-    .command(['api:update', 'org/api/2.0.0', '--publish'])
+    .command(['api:update', 'org/api/2.0.0', '--published=publish'])
 
     .it('runs api:update to publish API', ctx => {
       expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/apis`, api => api
+      .get('/org/api/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/apis`, api => api
+      .put('/org/api/2.0.0/settings/lifecycle', { published: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['api:update', 'org/api/2.0.0', '--published=unpublish'])
+
+    .it('runs api:update to publish API', ctx => {
+      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
     })
 
   test

--- a/test/commands/domain/setdefault.test.js
+++ b/test/commands/domain/setdefault.test.js
@@ -1,0 +1,45 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../src/config')
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('valid domain:setdefault', () => {
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  .nock(`${shubUrl}/domains`, domain => domain
+    .put('/org/domain/settings/default', { version: '2.0.0' })
+    .reply(200)
+  )
+  .stdout()
+  .command(['domain:setdefault', 'org/domain/2.0.0'])
+  .it('runs domain:setdefault with identifier', ctx => {
+    expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+  })
+})
+
+describe('invalid domain:setdefault', () => {
+  test
+  .command(['domain:setdefault'])
+  .exit(2)
+  .it('runs domain:setdefault with no identifier provided')
+
+  test
+  .stderr()
+  .command(['domain:setdefault', 'owner/domain'])
+  .exit(2)
+  .it('runs domain:setdefault without version in identifier')
+
+  test
+  .command(['domain:setdefault', 'owner/domain/version', '--testing'])
+  .exit(2)
+  .it('runs domain:setdefault with unrecognised flag')
+
+  test
+  .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+  .nock(`${shubUrl}/domains`, domain => domain
+    .put('/org/domain/settings/default', { version: '1.2.3' })
+    .reply(404, '{ "code": 404, "message": "Unknown domain org/domain:1.2.3"}')
+  )
+  .command(['domain:setdefault', 'org/domain/1.2.3'])
+  .exit(2)
+  .it('runs domain:setdefault with invalid domain version')
+})

--- a/test/commands/domain/update.test.js
+++ b/test/commands/domain/update.test.js
@@ -1,0 +1,436 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../src/config')
+const validIdentifier = 'org/domain/1.0.0'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('invalid domain:update command issues', () => {
+  test
+    .command(['domain:update'])
+    .exit(2)
+    .it('runs domain:update with no identifier provided')
+
+  test
+    .command(['domain:update', 'invalid'])
+    .catch(err => {
+      expect(err.message).to.contains('No updates specified')
+    })
+    .it('runs domain:update with no required --file flag')
+
+  test
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility'])
+    .catch(err => {
+      expect(err.message).to.equal('Flag --visibility expects a value')
+    })
+    .it('runs domain:update with no required --visibility flag')
+
+  test
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility=unexpected'])
+    .catch(err => {
+      expect(err.message).to.equal('Expected --visibility=unexpected to be one of: public, private\n' +
+        'See more help with --help')
+    })
+    .it('runs domain:update with unexpected value for required --visibility flag')
+
+  test
+    .command(['domain:update', 'owner', '-f=test/resources/valid_domain.yaml'])
+    .exit(2)
+    .it('runs domain:update with org identifier provided')
+})
+
+describe('invalid domain:update file issues', () => {
+  test
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/missing_file.yaml'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/missing_file.yaml\' not found')
+    })
+    .it('runs domain:update with file not found')
+
+  test
+    .command(['domain:update', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('Ensure the definition is valid.')
+    })
+    .it('runs domain:update with incorrectly formatted file')
+
+  test
+    .command(['domain:update', 'org/domain', '--file=test/resources/missing_version.yaml'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('Cannot determine version from file')
+    })
+    .it('runs domain:update with file missing version')
+})
+
+describe('invalid domain:update', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(404, '{"code": 404, "message": "Unknown domain org/domain/1.0.0"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml'])
+    .exit(2)
+    .it('runs domain:update with domain version not found')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(500, '{"code": 500, "message": "Error"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml'])
+    .exit(2)
+    .it('runs domain:update with error retrieving domain version')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(400, '{"code": 400, "error": "Bad Request"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .exit(2)
+    .it('runs domain:update with error on updating domain')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(404, '{"code": 404, "message": "Unknown domain org/domain/1.0.0"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--publish', '--setdefault'])
+    .catch(err => {
+      expect(err.message).to.contains('Unknown domain org/domain/1.0.0')
+    })
+    .it('error shows as update failed and publish and setdefault are not executed')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/1.0.0/settings/lifecycle')
+      .reply(500, '{ "code": 500, "message": "An error occurred. Publishing domain failed"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--setdefault', '--publish'])
+    .catch(err => {
+      expect(err.message).to.contains('An error occurred. Publishing domain failed')
+    })
+    .it('error shows as publish failed and setdefault is not executed')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/1.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '1.0.0' })
+      .reply(500, '{ "code": 500, "message": "An error occurred. Setting default version failed"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--publish', '--setdefault'])
+    .catch(err => {
+      expect(err.message).to.contains('An error occurred. Setting default version failed')
+    })
+    .it('error shows as setdefault failed')
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+
+    .stdout()
+    .command(['domain:update', 'org/domain/2.0.0'])
+
+    .catch(err => {
+      expect(err.message).to.contains('No updates specified')
+    })
+    .it('error shows as no flag is provided')
+})
+
+describe('valid domain:update', () => {
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml'])
+
+    .it('runs domain:update with YAML file', ctx => {
+      expect(ctx.stdout).to.contains(`Updated domain ${validIdentifier}`)
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3')
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json'])
+
+    .it('runs domain:update with JSON file, version read from file', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3&isPrivate=false')
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility=public'])
+
+    .it('runs domain:update to set domain public', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3&isPrivate=true')
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility=private'])
+
+    .it('runs domain:update to set domain private', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '--visibility=public'])
+
+    .it('runs domain:update to set domain public without a version arg', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to public')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/2.0.0/settings/private', { private: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain/2.0.0', '--visibility=private'])
+
+    .it('runs domain:update to set domain private', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to private')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/1.2.3/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--publish'])
+
+    .it('runs domain:update to publish domain', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '1.2.3' })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--setdefault'])
+
+    .it('runs domain:update to set default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/2.0.0/settings/private', { private: false })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain/2.0.0', '--visibility=public', '--publish', '--setdefault'])
+
+    .it('runs domain:update to set domain public, publish domain, and set the default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to public')
+      expect(ctx.stdout).to.contains('Published domain org/domain/2.0.0')
+      expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3&isPrivate=false')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '1.2.3' })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/1.2.3/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command([
+      'domain:update',
+      'org/domain',
+      '-f=test/resources/valid_domain.json',
+      '--visibility=public',
+      '--publish',
+      '--setdefault'
+    ])
+
+    .it('runs domain:update to set domain public, publish domain, and set the default version with file flag', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3 and visibility is set to public')
+      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.2.3')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/1.2.3/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '1.2.3' })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--setdefault', '--publish'])
+
+    .it('runs domain:update to publish domain and set default version', ctx => {
+      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/2.0.0/settings/lifecycle', { published: true })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain/2.0.0', '--publish'])
+
+    .it('runs domain:update to publish domain', ctx => {
+      expect(ctx.stdout).to.contains('Published domain org/domain/2.0.0')
+    })
+
+  test
+    .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/settings/default')
+      .reply(200, { version: '2.0.0' })
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .put('/org/domain/settings/default', { version: '2.0.0' })
+      .reply(200)
+    )
+    .stdout()
+    .command(['domain:update', 'org/domain/2.0.0', '--setdefault'])
+
+    .it('runs domain:update to set default version', ctx => {
+      expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+    })
+})


### PR DESCRIPTION
## Proposed Changes
  - Adds `domain:update` and `domain:setdefault` commands.
  - Extract `updateVisibility` to `UpdateCommand` class.
  - Add tests for update and setdefault.
  - Change `publish` flag to `published=publish|unpublish` to allow unpublishing on update.

