### PR TITLE
fix: Improve error message when parsing incorrectly formatted file

### DIFF
--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -9,7 +9,7 @@ const errorMsg = {
 
   argsMustMatchFormat: 'Argument must match {{format}} format',
 
-  cannotParseDefinition: 'There was a problem with parsing {{filename}}. Ensure the definition is valid. {{e}}',
+  cannotParseDefinition: 'There was a problem with parsing {{filename}}. \nReason: {{e}}',
 
   cannotParseOasVersion: 'Cannot determine OAS version from file',
 

--- a/src/utils/oas.js
+++ b/src/utils/oas.js
@@ -29,7 +29,7 @@ const parseDefinition = filename => {
   try {
     return hasJsonStructure(file) ? JSON.parse(file) : yaml.load(file) 
   } catch (e) {
-    throw new CLIError(errorMsg.cannotParseDefinition({ filename, e: JSON.stringify(e) }))
+    throw new CLIError(errorMsg.cannotParseDefinition({ filename, e: JSON.stringify(e.message).replace(/\\n/g, '\n') }))
   }
 }
 

--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -31,7 +31,7 @@ describe('invalid api:create file issues', () => {
   test
     .command(['api:create', validIdentifier, '--file=test/resources/invalid_format.yaml'])
     .catch(ctx => {
-      expect(ctx.message).to.contain('Ensure the definition is valid.')
+      expect(ctx.message).to.contain('There was a problem with parsing test/resources/invalid_format.yaml.')
     })
     .it('runs api:create with incorrectly formatted file')
 

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -56,7 +56,7 @@ describe('invalid api:update file issues', () => {
   test
     .command(['api:update', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
     .catch(ctx => {
-      expect(ctx.message).to.contain('Ensure the definition is valid.')
+      expect(ctx.message).to.contain('There was a problem with parsing test/resources/invalid_format.yaml.')
     })
     .it('runs api:update with incorrectly formatted file')
 

--- a/test/commands/domain/create.test.js
+++ b/test/commands/domain/create.test.js
@@ -31,7 +31,7 @@ describe('invalid domain:create file issues', () => {
   test
     .command(['domain:create', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
     .catch(ctx => {
-      expect(ctx.message).to.contain('Ensure the definition is valid.')
+      expect(ctx.message).to.contain('There was a problem with parsing test/resources/invalid_format.yaml.')
     })
     .it('runs domain:create with incorrectly formatted file')
 

--- a/test/commands/domain/update.test.js
+++ b/test/commands/domain/update.test.js
@@ -56,7 +56,7 @@ describe('invalid domain:update file issues', () => {
   test
     .command(['domain:update', `${validIdentifier}`, '--file=test/resources/invalid_format.yaml'])
     .catch(ctx => {
-      expect(ctx.message).to.contain('Ensure the definition is valid.')
+      expect(ctx.message).to.contain('There was a problem with parsing test/resources/invalid_format.yaml.')
     })
     .it('runs domain:update with incorrectly formatted file')
 


### PR DESCRIPTION
Improves error message when file incorrectly formatted.
Before -> 
```
swaggerhub-cli domain:update MixpanelDemo/DemoDomain -f ~/Downloads/MixpanelDemo-DemoDomain-1.0.0-domain.json
 ›   Error: There was a problem with parsing /Users/conor.ward/Downloads/MixpanelDemo-DemoDomain-1.0.0-domain.json. Ensure
 ›   the definition is valid. {"name":"YAMLException","reason":"missed comma between flow collection
 ›   entries","mark":{"name":null,"buffer":"{\n  \"info\" : {\n    \"description\" : \"This is a sample Domain updated by CLI
 ›    by version in file\",\n    \"version\" : \"1.0.0\",\n    \"title\" : \"Sample Domain\"\n  },\n  \"definitions\" : {\n
 ›     \"ErrorModel\" : {\n      \"required\" : [ \"code\", \"message\" ],\n      \"properties\" :\n        \"code\" : {\n
 ›          \"type\" : \"integer\",\n          \"format\" : \"int32\"\n        },\n        \"message\" : {\n
 ›   \"type\" : \"string\"\n        }\n      }\n    }\n  }\n}\n","position":275,"line":10,"column":15,"snippet":"  8 |
 ›   \"ErrorModel\" : {\n  9 |       \"required\" : [ \"code\", \"message\" ],\n 10 |       \"properties\" :\n 11 |
 ›   \"code\" : {\n---------------------^\n 12 |           \"type\" : \"integer\",\n 13 |           \"format\" :
 ›   \"int32\""},"message":"missed comma between flow collection entries (11:16)\n\n  8 |     \"ErrorModel\" : {\n  9 |
 ›    \"required\" : [ \"code\", \"message\" ],\n 10 |       \"properties\" :\n 11 |         \"code\" :
 ›   {\n---------------------^\n 12 |           \"type\" : \"integer\",\n 13 |           \"format\" : \"int32\""}
```
After ->
```
swaggerhub-cli domain:update MixpanelDemo/DemoDomain -f ~/Downloads/MixpanelDemo-DemoDomain-1.0.0-domain.json
 ›   Error: There was a problem with parsing /Users/conor.ward/Downloads/MixpanelDemo-DemoDomain-1.0.0-domain.json.
 ›   Reason: "missed comma between flow collection entries (11:16)
 ›
 ›     8 |     \"ErrorModel\" : {
 ›     9 |       \"required\" : [ \"code\", \"message\" ],
 ›    10 |       \"properties\" :
 ›    11 |         \"code\" : {
 ›   ---------------------^
 ›    12 |           \"type\" : \"integer\",
 ›    13 |           \"format\" : \"int32\""
```
