### PR TITLE
chore: Fix Dockerfile IaC WhiteSource violations

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 output=$(/cli/bin/run $*); status=$?;
-echo "::set-output name=response::$output"
+echo "::set-output name=response::
+$output"
 exit $status

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM node:12-alpine
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
 WORKDIR /cli
 COPY package*.json ./
 COPY ./bin ./bin
@@ -6,4 +8,5 @@ COPY ./src ./src
 COPY ./LICENSE ./LICENSE
 COPY ./.github/action/entrypoint.sh ./gh_entrypoint.sh
 RUN npm install
-ENTRYPOINT ["/cli/bin/run"]
+HEALTHCHECK --interval=15s --timeout=3s CMD curl --fail ${SWAGGERHUB_URL} || exit 1
+ENTRYPOINT ["/cli/gh_entrypoint.sh"]


### PR DESCRIPTION
Updated Dockerfile to rectify IaC security warnings flagged by WhiteSource  
Closes #221 and #222 
 
## Proposed Changes  
  
  - Added `appuser:appgroup` user to container to prevent running container as root   
  - Added healthcheck command to try and reach ${SWAGGERHUB_URL} and fail if it cannot be reached  
  - Modified entrypoint to use `gh_entrypoint.sh` instead of `/cli/bin/run`  
    - Container can now be built with `docker build -t smartbear/swaggerhub-cli:latest .`
    - and run with `docker run -e SWAGGERHUB_API_KEY="$API_KEY" -e SWAGGERHUB_URL="$SWH_URL" smartbear/swaggerhub-cli:latest $ARGS`
  - Added linebreak in entrypoint.sh for showing output under prefix line

