### PR TITLE
feat: Added functionality to update a project

### DIFF
--- a/src/commands/project/member/list.js
+++ b/src/commands/project/member/list.js
@@ -1,0 +1,54 @@
+const { getProject } = require('../../../requests/project')
+const { getResponseContent } = require('../../../support/command/handle-response')
+const BaseCommand = require('../../../support/command/base-command')
+const { getProjectIdentifierArg } = require('../../../support/command/parse-input')
+const { prettyPrintJSON } = require('../../../utils/general')
+
+class ListProjectMembersCommand extends BaseCommand {
+    constructor(...props) {
+        super(...props)
+        this.logProjectMembers = this.logProjectMembers.bind(this)
+    }
+
+    async run() {
+        const { args } = this.parse(ListProjectMembersCommand)
+        const projectPath = getProjectIdentifierArg(args)
+        await this.getProjectMembers(projectPath)
+    }
+
+    async logProjectMembers(response) {
+        const responseObj = JSON.parse(await getResponseContent(response))
+        if (responseObj.members.length === 0){
+            this.log('No members found.')
+        } else {
+            this.log(prettyPrintJSON(JSON.stringify(responseObj)))
+        }
+    }
+
+    async getProjectMembers(projectPath) {
+        return this.executeHttp({
+            execute: () => getProject([projectPath,'members']),
+            onResolve: this.logProjectMembers,
+            options: {}
+        })
+    }
+}
+
+ListProjectMembersCommand.description = 'list members of a project'
+
+ListProjectMembersCommand.examples = [
+    'swaggerhub project:list',
+    'swaggerhub project:list organization'
+]
+
+ListProjectMembersCommand.args = [{
+    name: 'OWNER/PROJECT_NAME',
+    required: true,
+    description: 'Project to list members of'
+}]
+
+ListProjectMembersCommand.flags = {
+    ...BaseCommand.flags
+}
+
+module.exports = ListProjectMembersCommand

--- a/src/commands/project/spec/add.js
+++ b/src/commands/project/spec/add.js
@@ -1,0 +1,55 @@
+const { putProject } = require('../../../requests/project')
+const {
+    getProjectIdentifierArg,
+    getSpecTypeIdentifierArg
+} = require('../../../support/command/parse-input')
+const BaseCommand = require('../../../support/command/base-command')
+
+class AddSpecCommand extends BaseCommand {
+
+    async run() {
+        const { args } = this.parse(AddSpecCommand)
+        const projectPath = getProjectIdentifierArg(args)
+        const specType = getSpecTypeIdentifierArg(args)
+        const specName = args['SPEC_NAME']
+
+        await this.addSpecToProject(projectPath, specType, specName)
+    }
+
+    async addSpecToProject(projectPath, specType, specName) {
+
+        return this.executeHttp({
+            execute: () => putProject({ pathParams: [projectPath, specType, specName] }),
+            onResolve: this.logCommandSuccess({ specName, specType, projectPath }),
+            options: {}
+        })
+    }
+}
+
+AddSpecCommand.description = 'Adds a spec to an existing project.'
+
+
+AddSpecCommand.examples = [
+    'swaggerhub project:spec:add organization/project_name apis my_api',
+    'swaggerhub project:spec:add organization/project_name domains my_domain'
+]
+
+AddSpecCommand.args = [
+    {
+        name: 'OWNER/PROJECT_NAME',
+        required: true,
+        description: 'The project to add the spec to'
+    },
+    {
+        name: 'SPEC_TYPE',
+        required: true,
+        description: 'The type of the spec to add, either \'apis\' or \'domains\''
+    },
+    {
+        name: 'SPEC_NAME',
+        required: true,
+        description: 'The name of the spec to add'
+    }
+]
+
+module.exports = AddSpecCommand

--- a/src/commands/project/update.js
+++ b/src/commands/project/update.js
@@ -1,0 +1,82 @@
+const { flags } = require('@oclif/command')
+const { putProject } = require('../../requests/project')
+const {
+    getProjectIdentifierArg,
+    splitPathParams,
+    splitFlagParams
+} = require('../../support/command/parse-input')
+const BaseCommand = require('../../support/command/base-command')
+
+class UpdateProjectCommand extends BaseCommand {
+
+    async run() {
+        const { args, flags } = this.parse(UpdateProjectCommand)
+        const projectPath = getProjectIdentifierArg(args)
+        const [owner, projectName] = splitPathParams(projectPath)
+        const body = {
+            'owner': owner,
+            'name': projectName
+        }
+        // Append optional flags to body if present
+        if (flags.description !== undefined) body.description = flags.description
+        if (flags.apis !== undefined) body.apis = splitFlagParams(flags.apis)
+        if (flags.domains !== undefined) body.domains = splitFlagParams(flags.domains)
+
+        await this.updateProject(owner, projectName, JSON.stringify(body))
+    }
+
+    async updateProject(owner, projectName, body) {
+        const createRequest = {
+            pathParams: [owner, projectName],
+            body: body
+        }
+
+        return this.executeHttp({
+            execute: () => putProject(createRequest),
+            onResolve: this.logCommandSuccess({ owner, projectName }),
+            options: {}
+        })
+    }
+}
+
+UpdateProjectCommand.description = 'Updates an existing project in SwaggerHub. ' +
+    'NOTE: Any non-included previous values will be removed when using this command.' +
+    'To add an single API or domain to a project, consider using project:api:add or project:domain:add'
+
+
+UpdateProjectCommand.examples = [
+    'swaggerhub project:update organization/project_name --description "project description"',
+    'swaggerhub project:update organization/project_name --a "testapi1,testapi2"',
+    'swaggerhub project:update organization/project_name --apis "testapi1,testapi2"',
+    'swaggerhub project:update organization/project_name -d "testdomain3,testdomain4"',
+    'swaggerhub project:update organization/project_name --domains "testdomain3,testdomain4"',
+    'swaggerhub project:update organization/project_name --domains "testdomain3,testdomain4"',
+    // eslint-disable-next-line max-len
+    'swaggerhub project:update organization/project_name -a "testapi,testapi2" -d "testdomain,testdomain2" --description "description of project"'
+]
+
+UpdateProjectCommand.args = [{
+    name: 'OWNER/PROJECT_NAME',
+    required: true,
+    description: 'The project to update'
+}]
+
+UpdateProjectCommand.flags = {
+    description: flags.string({
+        description: 'Description of project',
+        required: false
+    }),
+    apis: flags.string({
+        char: 'a',
+        description: 'Comma separated list of api names to include in project',
+        required: false
+    }),
+    domains: flags.string({
+        char: 'd',
+        description: 'Comma separated list of domain names to include in project',
+        required: false
+    }),
+    ...BaseCommand.flags
+}
+
+module.exports = UpdateProjectCommand

--- a/src/commands/project/update.js
+++ b/src/commands/project/update.js
@@ -12,23 +12,23 @@ class UpdateProjectCommand extends BaseCommand {
     async run() {
         const { args, flags } = this.parse(UpdateProjectCommand)
         const projectPath = getProjectIdentifierArg(args)
-        const [owner, projectName] = splitPathParams(projectPath)
+        const [owner, name] = splitPathParams(projectPath)
         const body = {
-            'owner': owner,
-            'name': projectName
+            owner,
+            name
         }
         // Append optional flags to body if present
         if (flags.description !== undefined) body.description = flags.description
         if (flags.apis !== undefined) body.apis = splitFlagParams(flags.apis)
         if (flags.domains !== undefined) body.domains = splitFlagParams(flags.domains)
 
-        await this.updateProject(owner, projectName, JSON.stringify(body))
+        await this.updateProject(owner, name, JSON.stringify(body))
     }
 
     async updateProject(owner, projectName, body) {
         const createRequest = {
             pathParams: [owner, projectName],
-            body: body
+            body
         }
 
         return this.executeHttp({

--- a/src/requests/project.js
+++ b/src/requests/project.js
@@ -1,4 +1,4 @@
-const { getSpec, postSpec } = require('./spec')
+const { getSpec, postSpec, putSpec } = require('./spec')
 
 const getProject = (pathParams, queryParams, accept = 'json') =>
     getSpec('projects', pathParams, queryParams, accept)
@@ -6,7 +6,11 @@ const getProject = (pathParams, queryParams, accept = 'json') =>
 const postProject = ({ pathParams, queryParams, body }) =>
     postSpec('projects', pathParams, queryParams, body)
 
+const putProject = ({ pathParams, body }) =>
+    putSpec('projects', pathParams, body)
+
 module.exports = {
     getProject,
-    postProject
+    postProject,
+    putProject
 }

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -7,6 +7,7 @@ const optionalVersionRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+(\/[\w\-.]+)?(\/?
 const requiredVersionRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+\/[\w\-.]+(\/?)$/)
 const integrationIdentifierRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+\/[\w\-.]+\/[\w\-.]+(\/?)$/)
 const projectIdentifierRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+$/)
+const specTypeIdentifierRegex = new RegExp(/^(\bapis\b|\bdomains\b)$/)
 
 const isValidIdentifier = (id, isVersionRequired) => isVersionRequired
   ? requiredVersionRegex.test(id)
@@ -52,6 +53,15 @@ const getProjectIdentifierArg = args => {
   return identifier
 }
 
+const getSpecTypeIdentifierArg = args => {
+  const format = 'SPEC_TYPE'
+  const identifier = args[format]
+  if (!specTypeIdentifierRegex.test(identifier)) {
+    throw new CLIError(errorMsg.argsMustMatchFormat({ format }))
+  }
+  return identifier
+}
+
 const readConfigFile = filename => {
   if (!existsSync(filename)) {
     throw new CLIError(errorMsg.fileNotFound({ filename }))
@@ -81,6 +91,7 @@ module.exports = {
   getDomainIdentifierArg,
   getIntegrationIdentifierArg,
   getProjectIdentifierArg,
+  getSpecTypeIdentifierArg,
   readConfigFile,
   splitPathParams,
   splitFlagParams,

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -45,7 +45,9 @@ const infoMsg = {
 
   Configure: 'Saved config to {{configFilePath}}',
 
-  ProjectCreate: 'Created project \'{{projectName}}\''
+  ProjectCreate: 'Created project \'{{projectName}}\'',
+
+  ProjectUpdate: 'Updated project \'{{owner}}/{{projectName}}\''
 }
 
 module.exports = wrapTemplates({

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -49,7 +49,10 @@ const infoMsg = {
 
   ProjectUpdate: 'Updated project \'{{owner}}/{{projectName}}\'',
 
+  ProjectSpecAdd: 'Added spec \'{{specName}}\' ({{specType}}) to project \'{{projectPath}}\'',
+
   ProjectDelete: 'Deleted project \'{{projectPath}}\''
+
 }
 
 module.exports = wrapTemplates({

--- a/test/commands/project/member/list.test.js
+++ b/test/commands/project/member/list.test.js
@@ -1,0 +1,69 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../../src/config')
+const validIdentifier= 'testowner/testproject'
+const shubUrl = 'https://test.api.swaggerhub.com'
+const membersResponse = {
+    'members': [
+        {
+            'name': 'testuser',
+            'type': 'USER',
+            'roles': [
+                'OWNER',
+                'MEMBER'
+            ]
+        }
+    ]
+}
+
+
+
+describe('valid project:member:list', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(200, { members: [] })
+        )
+        .stdout()
+        .command(['project:member:list', validIdentifier])
+        .it('runs project:member:list ands finds no members', ctx => {
+            expect(ctx.stdout).to.contain('No members found.')
+        })
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(200, membersResponse)
+        )
+        .stdout()
+        .command(['project:member:list', validIdentifier])
+        .it('runs project:member:list and finds one member', ctx => {
+            expect(ctx.stdout).to.contain('"type": "USER",')
+        })
+})
+
+describe('invalid project:list command issues', () => {
+    test
+        .command(['project:member:list'])
+        .exit(2)
+        .it('runs project:member:list with an no identifier')
+
+    test
+        .command(['project:member:list', 'testowner'])
+        .exit(2)
+        .it('runs project:member:list with an no project name')
+})
+
+describe('invalid project:list', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(404, membersResponse)
+        )
+        .command(['project:member:list', 'testowner/testproject'])
+        .exit(2)
+        .it('project not found, command fails')
+})
+

--- a/test/commands/project/spec/add.test.js
+++ b/test/commands/project/spec/add.test.js
@@ -1,0 +1,97 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../../src/config')
+const validIdentifier = 'testowner/testproject'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('invalid project:spec:add command issues', () => {
+    test
+        .command(['project:spec:add'])
+        .exit(2)
+        .it('runs project:spec:add with no identifier provided')
+
+    test
+        .command(['project:spec:add', 'invalid'])
+        .exit(2)
+        .it('runs project:spec:add with no project name specified')
+
+    test
+        .command(['project:spec:add', `${validIdentifier}`])
+        .exit(2)
+        .it('runs project:spec:add with no spec type or name')
+
+    test
+        .command(['project:spec:add', `${validIdentifier}`, 'notapis','testapiname'])
+        .exit(2)
+        .it('runs project:spec:add with invalid spec type')
+})
+
+describe('valid project:spec:add',
+    () => {
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}/apis/testapi`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+            .it('runs project:spec:add with \'apis\' spec type', ctx => {
+                expect(ctx.stdout).to.contains('Added spec \'testapi\' (apis) to project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}/domains/testdomain`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:spec:add', `${validIdentifier}`, 'domains', 'testdomain'])
+            .it('runs project:spec:add with \'domains\' spec type', ctx => {
+                expect(ctx.stdout).to.contains("Added spec 'testdomain' (domains) to project 'testowner/testproject'")
+            })
+    })
+
+describe('invalid project:spec:add', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .matchHeader('Content-Type', 'application/json')
+            .reply(404, { message: 'Project \'testproject\' does not exist' })
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+        })
+        .it('runs project:spec:add with a project that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .reply(404, { message: 'Unknown owner \'testowner\'' })
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.equal('Unknown owner \'testowner\'')
+        })
+        .it('runs project:spec:add with an owner that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .reply(409, {
+                    'error': 'The spec already exists in the project'
+                }
+            )
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('The spec already exists in the project')
+        })
+        .it('runs project:spec:add with an api that already exists in the project')
+})

--- a/test/commands/project/update.test.js
+++ b/test/commands/project/update.test.js
@@ -1,0 +1,137 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../src/config')
+const validIdentifier = 'testowner/testproject'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('invalid project:update command issues', () => {
+    test
+        .command(['project:update'])
+        .exit(2)
+        .it('runs project:update with no identifier provided')
+
+    test
+        .command(['project:update', 'invalid'])
+        .exit(2)
+        .it('runs project:update with no project name specified')
+
+    test
+        .command(['project:update', `${validIdentifier}`, '-f "not a valid flag"'])
+        .exit(2)
+        .it('runs project:update with invalid flag')
+})
+
+describe('valid project:update',
+    () => {
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:update', `${validIdentifier}`])
+            .it('runs project:update with no flags', ctx => {
+                expect(ctx.stdout).to.contains('Updated project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:update', `${validIdentifier}`, '--apis=testapi1,testapi2'])
+            .it('runs project:update with --apis flags', ctx => {
+                expect(ctx.stdout).to.contains('Updated project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:update', `${validIdentifier}`, '--domains=testdomain1,testdomain2'])
+            .it('runs project:update with --domains flags', ctx => {
+                expect(ctx.stdout).to.contains('Updated project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:update', `${validIdentifier}`, '--description="test project description"'])
+            .it('runs project:update with --description flag', ctx => {
+                expect(ctx.stdout).to.contains('Updated project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command([
+                'project:update',
+                `${validIdentifier}`,
+                '--description="test project description"',
+                '--domains=testdomain1,testdomain2',
+                '--apis=testapi1,testapi2'
+            ])
+            .it('runs project:update with all valid flags', ctx => {
+                expect(ctx.stdout).to.contains('Updated project \'testowner/testproject\'')
+            })
+    })
+
+describe('invalid project:update', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}`)
+            .matchHeader('Content-Type', 'application/json')
+            .reply(404, { message: 'Project \'testproject\' does not exist' })
+        )
+        .command(['project:update', `${validIdentifier}`])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+        })
+        .it('runs project:update with a project that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}`)
+            .reply(404, { message: 'Unknown owner \'testowner\'' })
+        )
+        .command(['project:update', `${validIdentifier}`])
+        .catch(ctx => {
+            expect(ctx.message).to.equal('Unknown owner \'testowner\'')
+        })
+        .it('runs project:update with an owner that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}`)
+            .reply(400, {
+                    'error': 'Unable to save project. Some api/domain entries are invalid.'
+                }
+            )
+        )
+        .command(['project:update', `${validIdentifier}`, '--apis=apithatdoesnotexist,testapi2'])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('Unable to save project. Some api/domain entries are invalid.')
+        })
+        .it('runs project:update with an api that doesn\'t exist')
+})


### PR DESCRIPTION
Added functionality to update a project
Part of #199 

## Proposed Changes
  - added command `swaggerhub project update owner/project_name` with optional flags:
    - `--description` (Description of project)
    - `-a` or `--apis` (Comma separated list of api names to include in project)
    - `-d` or `--domains` (Comma separated list of domain names to include in project)
  - Added not in command description to inform user that using this command will overwrite whatever is currently saved, and that if they don't include all APIs/domains in the command with the appropriate flags they will be removed

