### PR TITLE
feat: Added functionality to list members of a project

### DIFF
--- a/src/commands/project/member/list.js
+++ b/src/commands/project/member/list.js
@@ -28,7 +28,7 @@ class ListProjectMembersCommand extends BaseCommand {
     async getProjectMembers(projectPath) {
         return this.executeHttp({
             execute: () => getProject([projectPath,'members']),
-            onResolve: this.logProject,
+            onResolve: this.logProjectMembers,
             options: {}
         })
     }

--- a/src/commands/project/member/list.js
+++ b/src/commands/project/member/list.js
@@ -1,0 +1,54 @@
+const { getProject } = require('../../../requests/project')
+const { getResponseContent } = require('../../../support/command/handle-response')
+const BaseCommand = require('../../../support/command/base-command')
+const { getProjectIdentifierArg } = require('../../../support/command/parse-input')
+const { prettyPrintJSON } = require('../../../utils/general')
+
+class ListProjectMembersCommand extends BaseCommand {
+    constructor(...props) {
+        super(...props)
+        this.logProjectMembers = this.logProjectMembers.bind(this)
+    }
+
+    async run() {
+        const { args } = this.parse(ListProjectMembersCommand)
+        const projectPath = getProjectIdentifierArg(args)
+        await this.getProjectMembers(projectPath)
+    }
+
+    async logProjectMembers(response) {
+        const responseObj = JSON.parse(await getResponseContent(response))
+        if (responseObj.members.length === 0){
+            this.log('No members found.')
+        } else {
+            this.log(prettyPrintJSON(JSON.stringify(responseObj)))
+        }
+    }
+
+    async getProjectMembers(projectPath) {
+        return this.executeHttp({
+            execute: () => getProject([projectPath,'members']),
+            onResolve: this.logProject,
+            options: {}
+        })
+    }
+}
+
+ListProjectMembersCommand.description = 'list members of a project'
+
+ListProjectMembersCommand.examples = [
+    'swaggerhub project:list',
+    'swaggerhub project:list organization'
+]
+
+ListProjectMembersCommand.args = [{
+    name: 'OWNER/PROJECT_NAME',
+    required: true,
+    description: 'Project to list members of'
+}]
+
+ListProjectMembersCommand.flags = {
+    ...BaseCommand.flags
+}
+
+module.exports = ListProjectMembersCommand

--- a/src/commands/project/spec/add.js
+++ b/src/commands/project/spec/add.js
@@ -1,0 +1,55 @@
+const { putProject } = require('../../../requests/project')
+const {
+    getProjectIdentifierArg,
+    getSpecTypeIdentifierArg
+} = require('../../../support/command/parse-input')
+const BaseCommand = require('../../../support/command/base-command')
+
+class AddSpecCommand extends BaseCommand {
+
+    async run() {
+        const { args } = this.parse(AddSpecCommand)
+        const projectPath = getProjectIdentifierArg(args)
+        const specType = getSpecTypeIdentifierArg(args)
+        const specName = args['SPEC_NAME']
+
+        await this.addSpecToProject(projectPath, specType, specName)
+    }
+
+    async addSpecToProject(projectPath, specType, specName) {
+
+        return this.executeHttp({
+            execute: () => putProject({ pathParams: [projectPath, specType, specName] }),
+            onResolve: this.logCommandSuccess({ specName, specType, projectPath }),
+            options: {}
+        })
+    }
+}
+
+AddSpecCommand.description = 'Adds a spec to an existing project.'
+
+
+AddSpecCommand.examples = [
+    'swaggerhub project:spec:add organization/project_name apis my_api',
+    'swaggerhub project:spec:add organization/project_name domains my_domain'
+]
+
+AddSpecCommand.args = [
+    {
+        name: 'OWNER/PROJECT_NAME',
+        required: true,
+        description: 'The project to add the spec to'
+    },
+    {
+        name: 'SPEC_TYPE',
+        required: true,
+        description: 'The type of the spec to add, either \'apis\' or \'domains\''
+    },
+    {
+        name: 'SPEC_NAME',
+        required: true,
+        description: 'The name of the spec to add'
+    }
+]
+
+module.exports = AddSpecCommand

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -7,6 +7,7 @@ const optionalVersionRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+(\/[\w\-.]+)?(\/?
 const requiredVersionRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+\/[\w\-.]+(\/?)$/)
 const integrationIdentifierRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+\/[\w\-.]+\/[\w\-.]+(\/?)$/)
 const projectIdentifierRegex = new RegExp(/^\/?[\w\-.]+\/[\w\-.]+$/)
+const specTypeIdentifierRegex = new RegExp(/^(\bapis\b|\bdomains\b)$/)
 
 const isValidIdentifier = (id, isVersionRequired) => isVersionRequired
   ? requiredVersionRegex.test(id)
@@ -52,6 +53,15 @@ const getProjectIdentifierArg = args => {
   return identifier
 }
 
+const getSpecTypeIdentifierArg = args => {
+  const format = 'SPEC_TYPE'
+  const identifier = args[format]
+  if (!specTypeIdentifierRegex.test(identifier)) {
+    throw new CLIError(errorMsg.argsMustMatchFormat({ format }))
+  }
+  return identifier
+}
+
 const readConfigFile = filename => {
   if (!existsSync(filename)) {
     throw new CLIError(errorMsg.fileNotFound({ filename }))
@@ -81,6 +91,7 @@ module.exports = {
   getDomainIdentifierArg,
   getIntegrationIdentifierArg,
   getProjectIdentifierArg,
+  getSpecTypeIdentifierArg,
   readConfigFile,
   splitPathParams,
   splitFlagParams,

--- a/src/template-strings/info.js
+++ b/src/template-strings/info.js
@@ -47,7 +47,9 @@ const infoMsg = {
 
   ProjectCreate: 'Created project \'{{projectName}}\'',
 
-  ProjectUpdate: 'Updated project \'{{owner}}/{{projectName}}\''
+  ProjectUpdate: 'Updated project \'{{owner}}/{{projectName}}\'',
+
+  ProjectSpecAdd: 'Added spec \'{{specName}}\' ({{specType}}) to project \'{{projectPath}}\''
 }
 
 module.exports = wrapTemplates({

--- a/test/commands/project/member/list.test.js
+++ b/test/commands/project/member/list.test.js
@@ -1,0 +1,69 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../../src/config')
+const validIdentifier= 'testowner/testproject'
+const shubUrl = 'https://test.api.swaggerhub.com'
+const membersResponse = {
+    'members': [
+        {
+            'name': 'testuser',
+            'type': 'USER',
+            'roles': [
+                'OWNER',
+                'MEMBER'
+            ]
+        }
+    ]
+}
+
+
+
+describe('valid project:member:list', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(200, { members: [] })
+        )
+        .stdout()
+        .command(['project:member:list', validIdentifier])
+        .it('runs project:member:list ands finds no members', ctx => {
+            expect(ctx.stdout).to.contain('No members found.')
+        })
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(200, membersResponse)
+        )
+        .stdout()
+        .command(['project:member:list', validIdentifier])
+        .it('runs project:member:list and finds one member', ctx => {
+            expect(ctx.stdout).to.contain('"type": "USER",')
+        })
+})
+
+describe('invalid project:list command issues', () => {
+    test
+        .command(['project:member:list'])
+        .exit(2)
+        .it('runs project:member:list with an no identifier')
+
+    test
+        .command(['project:member:list', 'testowner'])
+        .exit(2)
+        .it('runs project:member:list with an no project name')
+})
+
+describe('invalid project:list', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, { reqheaders: { accept: 'application/json' } }, projects => projects
+            .get(`/${validIdentifier}/members`)
+            .reply(404, membersResponse)
+        )
+        .command(['project:member:list', 'testowner/testproject'])
+        .exit(2)
+        .it('project not found, command fails')
+})
+

--- a/test/commands/project/spec/add.test.js
+++ b/test/commands/project/spec/add.test.js
@@ -1,0 +1,97 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../../src/config')
+const validIdentifier = 'testowner/testproject'
+const shubUrl = 'https://test-api.swaggerhub.com'
+
+describe('invalid project:spec:add command issues', () => {
+    test
+        .command(['project:spec:add'])
+        .exit(2)
+        .it('runs project:spec:add with no identifier provided')
+
+    test
+        .command(['project:spec:add', 'invalid'])
+        .exit(2)
+        .it('runs project:spec:add with no project name specified')
+
+    test
+        .command(['project:spec:add', `${validIdentifier}`])
+        .exit(2)
+        .it('runs project:spec:add with no spec type or name')
+
+    test
+        .command(['project:spec:add', `${validIdentifier}`, 'notapis','testapiname'])
+        .exit(2)
+        .it('runs project:spec:add with invalid spec type')
+})
+
+describe('valid project:spec:add',
+    () => {
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}/apis/testapi`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+            .it('runs project:spec:add with \'apis\' spec type', ctx => {
+                expect(ctx.stdout).to.contains('Added spec \'testapi\' (apis) to project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .put(`/${validIdentifier}/domains/testdomain`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200)
+            )
+            .stdout()
+            .command(['project:spec:add', `${validIdentifier}`, 'domains', 'testdomain'])
+            .it('runs project:spec:add with \'domains\' spec type', ctx => {
+                expect(ctx.stdout).to.contains("Added spec 'testdomain' (domains) to project 'testowner/testproject'")
+            })
+    })
+
+describe('invalid project:spec:add', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .matchHeader('Content-Type', 'application/json')
+            .reply(404, { message: 'Project \'testproject\' does not exist' })
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+        })
+        .it('runs project:spec:add with a project that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .reply(404, { message: 'Unknown owner \'testowner\'' })
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.equal('Unknown owner \'testowner\'')
+        })
+        .it('runs project:spec:add with an owner that doesn\'t exist')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+        .nock(`${shubUrl}/projects`, integration => integration
+            .put(`/${validIdentifier}/apis/testapi`)
+            .reply(409, {
+                    'error': 'The spec already exists in the project'
+                }
+            )
+        )
+        .command(['project:spec:add', `${validIdentifier}`,'apis','testapi'])
+        .catch(ctx => {
+            expect(ctx.message).to.contains('The spec already exists in the project')
+        })
+        .it('runs project:spec:add with an api that already exists in the project')
+})


### PR DESCRIPTION
Added functionality to list members of a project
Part of #199 


## Proposed Changes

  - Added command `swaggerhub project:member:list owner/project_name`

Currently this will return the names, types and roles associated with each user. Just wondering here if there may be an information disclosure worry for folks using this in CI in public projects? Should we have some granular way of choosing which data gets returned with flags?
