### PR TITLE
chore: Revert @oclif/plugin-help to v3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1370,7 +1370,7 @@
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
         "@oclif/errors": "^1.3.3",
-        "@oclif/plugin-help": "^3.2.0",
+        "@oclif/plugin-help": "^3.2.3",
         "cli-ux": "^5.2.1",
         "debug": "^4.1.1",
         "find-yarn-workspace-root": "^2.0.0",
@@ -1657,9 +1657,9 @@
       }
     },
     "@oclif/plugin-help": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.3.1.tgz",
-      "integrity": "sha512-QuSiseNRJygaqAdABYFWn/H1CwIZCp9zp/PLid6yXvy6VcQV7OenEFF5XuYaCvSARe2Tg9r8Jqls5+fw1A9CbQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.3.tgz",
+      "integrity": "sha512-l2Pd0lbOMq4u/7xsl9hqISFqyR9gWEz/8+05xmrXFr67jXyS6EUCQB+mFBa0wepltrmJu0sAFg9AvA2mLaMMqQ==",
       "requires": {
         "@oclif/command": "^1.8.15",
         "@oclif/config": "1.18.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@oclif/command": "^1.8.16",
     "@oclif/config": "^1.17.0",
     "@oclif/errors": "^1.3.4",
-    "@oclif/plugin-help": "^3.3.1",
+    "@oclif/plugin-help": "^3.2.3",
     "@oclif/plugin-plugins": "^2.0.11",
     "cli-ux": "^5.6.3",
     "deep-extend": "^0.6.0",


### PR DESCRIPTION
## Proposed Changes

  - Revert @oclif/plugin-help to v3.2.3 so that the `--help` flag works again

NOTE: Delete `node_modules` folder and run `npm ci` to apply changes