### PR TITLE
fix: Changed variable imported in help.js to work with updated version of @oclif/plugin-help

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -1,4 +1,4 @@
-const Help = require('@oclif/plugin-help').default
+const Help = require('@oclif/plugin-help').Help
 
 module.exports = class CustomHelp extends Help {
 


### PR DESCRIPTION
Changed variable imported in help.js to work with updated version of @oclif/plugin-help. This broke when @oclif/plugin-help was updated from 3.2.3 to 3.3.1 . Changed variable and --help flag now works again.

## Proposed Changes

  - Changed variable imported in help.js


