### PR TITLE
chore: Update oclif errors to 1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,7 +989,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
           "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
           "requires": {
-            "@oclif/errors": "^1.3.3",
+            "@oclif/errors": "^1.3.5",
             "@oclif/parser": "^3.8.0",
             "debug": "^4.1.1",
             "globby": "^11.0.1",
@@ -1123,7 +1123,7 @@
       "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
       "integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
@@ -1369,7 +1369,7 @@
       "requires": {
         "@oclif/command": "^1.8.0",
         "@oclif/config": "^1.17.0",
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/plugin-help": "^3.2.0",
         "cli-ux": "^5.2.1",
         "debug": "^4.1.1",
@@ -1402,9 +1402,9 @@
       }
     },
     "@oclif/errors": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.4.tgz",
-      "integrity": "sha512-pJKXyEqwdfRTUdM8n5FIHiQQHg5ETM0Wlso8bF9GodczO40mF5Z3HufnYWJE7z8sGKxOeJCdbAVZbS8Y+d5GCw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
+      "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
       "requires": {
         "clean-stack": "^3.0.0",
         "fs-extra": "^8.1",
@@ -1679,7 +1679,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
           "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
           "requires": {
-            "@oclif/errors": "^1.3.3",
+            "@oclif/errors": "^1.3.5",
             "@oclif/parser": "^3.8.0",
             "debug": "^4.1.1",
             "globby": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@oclif/command": "^1.8.16",
     "@oclif/config": "^1.17.0",
-    "@oclif/errors": "^1.3.4",
+    "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^3.3.1",
     "@oclif/plugin-plugins": "^2.0.11",
     "cli-ux": "^5.6.3",

--- a/src/help.js
+++ b/src/help.js
@@ -1,4 +1,4 @@
-const Help = require('@oclif/plugin-help').default
+const Help = require('@oclif/plugin-help').Help
 
 module.exports = class CustomHelp extends Help {
 


### PR DESCRIPTION
As per https://github.com/oclif/errors/pull/157 bumping @oclif/errors to 1.3.5 to get rid of false positive error message

## Proposed Changes

  - Update oclif errors to 1.3.5

