### PR TITLE
feat: Added script to format README after running `oclif-dev readme`

### DIFF
--- a/src/format-readme.js
+++ b/src/format-readme.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 
 const removeArgsFromHeaders = line => {
+    if (!line.includes('OWNER')) return line
     const words = line.split(' ')
     const filteredWords = words.filter(word => !word.startsWith('OWNER'))
     return `${filteredWords.join(' ')}\``
@@ -9,6 +10,7 @@ const removeArgsFromHeaders = line => {
 const removeArgsFromLinks = line => {
     const slug = line.substr(line.indexOf('#')+1, line.length-2)
     const words = slug.split('-')
+    if (words.length <= 2) return line
     return line.replace(slug, `${words[0]}-${words[1]})`)
 }
 

--- a/src/format-readme.js
+++ b/src/format-readme.js
@@ -1,10 +1,9 @@
 const fs = require('fs')
 
 const removeArgsFromHeaders = line => {
-    if (!line.includes('OWNER')) return line
     const words = line.split(' ')
-    const filteredWords = words.filter(word => !word.startsWith('OWNER'))
-    return `${filteredWords.join(' ')}\``
+    if (words.length <= 3) return line
+    return `## ${words[1]} ${words[2]}\``
 }
 
 const removeArgsFromLinks = line => {
@@ -17,7 +16,7 @@ const removeArgsFromLinks = line => {
 const main = () => {
     const outputBuffer = []
     try {
-        const data = fs.readFileSync('README.md', 'utf8')
+        const data = fs.readFileSync('../README.md', 'utf8')
         const lineBuffer = data.split('\n')
 
         lineBuffer.forEach(line => {

--- a/src/format-readme.js
+++ b/src/format-readme.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+
+const removeArgsFromHeaders = line => {
+    const words = line.split(' ')
+    const filteredWords = words.filter(word => !word.startsWith('OWNER'))
+    return `${filteredWords.join(' ')}\``
+}
+
+const removeArgsFromLinks = line => {
+    const slug = line.substr(line.indexOf('#')+1, line.length-2)
+    const words = slug.split('-')
+    return line.replace(slug, `${words[0]}-${words[1]})`)
+}
+
+const main = () => {
+    const outputBuffer = []
+    try {
+        const data = fs.readFileSync('README.md', 'utf8')
+        const lineBuffer = data.split('\n')
+
+        lineBuffer.forEach(line => {
+            if (line.startsWith('* [`swaggerhub')) return outputBuffer.push(removeArgsFromLinks(line))
+            if (line.startsWith('## `swaggerhub')) return outputBuffer.push(removeArgsFromHeaders(line))
+            return outputBuffer.push(line)
+        })
+
+        const output = outputBuffer.join('\n')
+        fs.writeFileSync('README.md', output)
+
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+if (require.main === module) {
+    main()
+}

--- a/src/format-readme.js
+++ b/src/format-readme.js
@@ -16,7 +16,7 @@ const removeArgsFromLinks = line => {
 const main = () => {
     const outputBuffer = []
     try {
-        const data = fs.readFileSync('../README.md', 'utf8')
+        const data = fs.readFileSync('README.md', 'utf8')
         const lineBuffer = data.split('\n')
 
         lineBuffer.forEach(line => {


### PR DESCRIPTION
Added script to format README after running oclif-dev readme
Proposed Changes

This script:

    removes parameters in the header links
        e.g. (#swaggerhub-apicreate-ownerapi_nameversion) => (#swaggerhub-apicreate)
    removes arguments from headers
        e.g. ## 'swaggerhub api:create OWNER/API_NAME/[VERSION]` => ## `swaggerhub api:create`
    preserves all other artifacts in the README file, updating only the changed lines

Now, instead of just running oclif-dev readme, run `oclif-dev readme && node src/format-readme.js`