### PR TITLE
fix: Added whitespace trimming for api and domain flags in project:create

### DIFF
--- a/src/commands/project/member/list.js
+++ b/src/commands/project/member/list.js
@@ -44,8 +44,7 @@ class ListProjectMembersCommand extends BaseCommand {
 ListProjectMembersCommand.description = 'list members of a project'
 
 ListProjectMembersCommand.examples = [
-    'swaggerhub project:list',
-    'swaggerhub project:list organization'
+    'swaggerhub project:member:list OWNER/PROJECT_NAME',
 ]
 
 ListProjectMembersCommand.args = [{

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -70,7 +70,7 @@ const readConfigFile = filename => {
 
 const splitPathParams = path => path.split('/').filter(Boolean)
 
-const splitFlagParams = flag => flag.replace(/\s+/g, '').split(',').filter(Boolean)
+const splitFlagParams = flag => flag.split(',').map(param => param.trim()).filter(Boolean)
 
 const reqType = ({ json }) => json ? 'json' : 'yaml'
 

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -70,7 +70,7 @@ const readConfigFile = filename => {
 
 const splitPathParams = path => path.split('/').filter(Boolean)
 
-const splitFlagParams = flag => flag.replace(/\s/g, '').split(',').filter(Boolean)
+const splitFlagParams = flag => flag.replace(/\s+/g, '').split(',').filter(Boolean)
 
 const reqType = ({ json }) => json ? 'json' : 'yaml'
 

--- a/src/support/command/parse-input.js
+++ b/src/support/command/parse-input.js
@@ -70,7 +70,7 @@ const readConfigFile = filename => {
 
 const splitPathParams = path => path.split('/').filter(Boolean)
 
-const splitFlagParams = flag => flag.split(',').filter(Boolean)
+const splitFlagParams = flag => flag.replace(/\s/g, '').split(',').filter(Boolean)
 
 const reqType = ({ json }) => json ? 'json' : 'yaml'
 

--- a/test/commands/project/create.test.js
+++ b/test/commands/project/create.test.js
@@ -57,6 +57,32 @@ describe('valid project:create',
                 .reply(201)
             )
             .stdout()
+            .command(['project:create', `${validIdentifier}`, '--apis="testapi1, testapi2,     testapi3"'])
+            .it('runs project:create with --apis flags with whitespace characters', ctx => {
+                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .post(`/${validOwner}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(201)
+            )
+            .stdout()
+            .command(['project:create', `${validIdentifier}`, '--domains="testdomain1,  testdomain2,        testdomain3"'])
+            .it('runs project:create with --domains flags with whitespace characters', ctx => {
+                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+            })
+
+        test
+            .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+            .nock(`${shubUrl}/projects`, integration => integration
+                .post(`/${validOwner}`)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(201)
+            )
+            .stdout()
             .command(['project:create', `${validIdentifier}`, '--domains=testdomain1,testdomain2'])
             .it('runs project:create with --domains flags', ctx => {
                 expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -7,7 +7,8 @@ const {
   getDomainIdentifierArg,
   getProjectIdentifierArg,
   readConfigFile,
-  reqType, splitFlagParams
+  reqType,
+  splitFlagParams
 } = require('../../src/support/command/parse-input')
 
 describe('reqType returns correct type', () => {

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -7,7 +7,7 @@ const {
   getDomainIdentifierArg,
   getProjectIdentifierArg,
   readConfigFile,
-  reqType 
+  reqType, splitFlagParams
 } = require('../../src/support/command/parse-input')
 
 describe('reqType returns correct type', () => {
@@ -31,6 +31,33 @@ describe('reqType returns correct type', () => {
   })
 })
 
+describe('splitFlagParams returns array of params', () => {
+
+  context('splitFlagParams(\'testapi1,testapi2,testapi3\')', () => {
+    it('should return 3 items', () => {
+      expect(splitFlagParams('testapi1,testapi2,testapi3').length).to.equal(3)
+    })
+  })
+
+  context('splitFlagParams(\'testapi1,    testapi2,     testapi3\')', () => {
+    it('should return 3 items', () => {
+      expect(splitFlagParams('testapi1,    testapi2,     testapi3').length).to.equal(3)
+    })
+  })
+
+  context('splitFlagParams(\'testapi1\')', () => {
+    it('should return 1 items', () => {
+      expect(splitFlagParams('testapi1').length).lengthOf.to.equal(1)
+    })
+  })
+
+  context('splitFlagParams(\'testapi1,,,,testapi2\')', () => {
+    it('should return 3 items', () => {
+      expect(splitFlagParams('testapi1,,,,testapi2').length).to.equal(2)
+    })
+  })
+
+})
 
 describe('Validate Object Identifier', () => {
 


### PR DESCRIPTION
Small fix for project:create flags

## Proposed Changes

  - As caught by @MateuszPol in testing, added regex to remove whitespace in --api and --domain flags to ensure they get parsed correctly

  - Update erroneous example string in project:member:list
  

