### PR TITLE
fix: Make appuser owner of /cli to prevent permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:12-alpine
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-USER appuser
 WORKDIR /cli
+RUN chown -R appuser:appgroup /cli
+USER appuser
 COPY package*.json ./
 COPY ./bin ./bin
 COPY ./src ./src


### PR DESCRIPTION
Fixes permissions issue when building swaggerhub-cli docker image.

The following error occurs when running swaggerhub-cli in github actions
``` 
Step 10/12 : RUN npm install
   ---> Running in 7d48a675d1b7
  npm WARN checkPermissions Missing write access to /cli
  npm ERR! code EACCES
  npm ERR! syscall access
  npm ERR! path /cli
  npm ERR! errno -13
  npm ERR! Error: EACCES: permission denied, access '/cli'
  npm ERR!  [Error: EACCES: permission denied, access '/cli'] {
  npm ERR!   errno: -13,
  npm ERR!   code: 'EACCES',
  npm ERR!   syscall: 'access',
  npm ERR!   path: '/cli'
  npm ERR! }
  npm ERR! 
  npm ERR! The operation was rejected by your operating system.
  npm ERR! It is likely you do not have the permissions to access this file as the current user
  npm ERR! 
  npm ERR! If you believe this might be a permissions issue, please double-check the
  npm ERR! permissions of the file and its containing directories, or try running
  npm ERR! the command again as root/Administrator.
```

## Proposed Changes

  - Make `appuser` owner of `/cli` directory.

