### PR TITLE
fix: update dockerfile to remove user command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:12-alpine
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /cli
-RUN chown -R appuser:appgroup /cli
-USER appuser
 COPY package*.json ./
 COPY ./bin ./bin
 COPY ./src ./src


### PR DESCRIPTION
Fixes (https://github.com/SmartBear/swaggerhub-cli/issues/254)

## Proposed Changes
  - Removal of `USER` command from `Dockerfile` as it is recommended in github [docs](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user) not to use it.

