### PR TITLE
fix: Added AsyncAPI support to {api/domain}:{create/update} commands

### DIFF
--- a/src/commands/api/update.js
+++ b/src/commands/api/update.js
@@ -2,7 +2,7 @@ const { flags } = require('@oclif/command')
 const { readFileSync } = require('fs-extra')
 const { getApi, postApi } = require('../../requests/api')
 const { getApiIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
-const { getVersion, parseDefinition } = require('../../utils/oas')
+const { getVersion, parseDefinition } = require('../../utils/definitions')
 const BaseCommand = require('../../support/command/base-command')
 const UpdateCommand = require('../../support/command/update-command')
 

--- a/src/commands/domain/create.js
+++ b/src/commands/domain/create.js
@@ -2,7 +2,7 @@ const { flags } = require('@oclif/command')
 const { readFileSync } = require('fs-extra')
 const { getDomain, postDomain } = require('../../requests/domain')
 const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
-const { getVersion, parseDefinition } = require('../../utils/oas')
+const { getVersion, parseDefinition } = require('../../utils/definitions')
 const BaseCommand = require('../../support/command/base-command')
 const UpdateCommand = require('../../support/command/update-command')
 

--- a/src/commands/domain/update.js
+++ b/src/commands/domain/update.js
@@ -2,7 +2,7 @@ const { flags } = require('@oclif/command')
 const { readFileSync } = require('fs-extra')
 const { getDomain, postDomain } = require('../../requests/domain')
 const { getDomainIdentifierArg, splitPathParams } = require('../../support/command/parse-input')
-const { getVersion, parseDefinition } = require('../../utils/oas')
+const { getVersion, parseDefinition } = require('../../utils/definitions')
 const BaseCommand = require('../../support/command/base-command')
 const UpdateCommand = require('../../support/command/update-command')
 

--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -11,7 +11,7 @@ const errorMsg = {
 
   cannotParseDefinition: 'There was a problem with parsing {{filename}}. \nReason: {{e}}',
 
-  cannotParseOasVersion: 'Cannot determine OAS version from file',
+  cannotParseSpecification: 'Cannot determine specification from file',
 
   cannotParseVersion: 'Cannot determine version from file',
 

--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -4,11 +4,20 @@ const yaml = require('js-yaml')
 const { existsSync, readFileSync } = require('fs-extra')
 const { errorMsg } = require('../template-strings')
 
-const getOasVersion = ({ swagger, openapi }) => {
-  if (!swagger && !openapi) {
-    throw new CLIError(errorMsg.cannotParseOasVersion())
+const specVersionToSpecification = specVersion => {
+  if (/2.0$/.test(specVersion))
+      return 'openapi-2.0'
+  if (/2.\d+.\d+$/.test(specVersion))
+    return 'asyncapi-2.x.x'
+  return 'openapi-3.0.0'
+}
+
+const getSpecification = ({ swagger, openapi, asyncapi }) => {
+  if (!swagger && !openapi && !asyncapi) {
+    throw new CLIError(errorMsg.cannotParseSpecification())
   }
-  return swagger || openapi
+  const specVersion = [swagger, openapi, asyncapi].filter(version => Boolean(version))[0]
+  return specVersionToSpecification(specVersion)
 }
 
 const getVersion = definition => {
@@ -34,7 +43,7 @@ const parseDefinition = filename => {
 }
 
 module.exports = {
-  getOasVersion,
+  getSpecification,
   getVersion,
   parseDefinition,
 }

--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -38,9 +38,9 @@ describe('invalid api:create file issues', () => {
   test
     .command(['api:create', validIdentifier, '--file=test/resources/missing_oas_version.yaml'])
     .catch(ctx => {
-      expect(ctx.message).to.contain('Cannot determine OAS version from file')
+      expect(ctx.message).to.contain('Cannot determine specification from file')
     })
-    .it('runs api:create with file missing OAS Version')
+    .it('runs api:create with file missing specification')
 
     test
     .command(['api:create', 'org/api', '--file=test/resources/missing_version.yaml'])
@@ -98,7 +98,7 @@ describe('invalid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/orgNotExist/api?version=1.0.0&isPrivate=true&oas=3.0.0')
+      .post('/orgNotExist/api?version=1.0.0&isPrivate=true&specification=openapi-3.0.0')
       .reply(404, '{"code":404,"message":"{\\\"code\\\":404,\\\"message\\\":\\\"Object doesn\'t exist\\\"}"}')
     )
     .command(['api:create', 'orgNotExist/api/1.0.0', '--file=test/resources/valid_api.json'])
@@ -114,7 +114,7 @@ describe('invalid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/overLimitApi?version=1.0.0&isPrivate=true&oas=3.0.0')
+      .post('/org/overLimitApi?version=1.0.0&isPrivate=true&specification=openapi-3.0.0')
       .reply(403, '{"code":403,"message":"You have reached the limit of APIs"}')
     )
     .command(['api:create', 'org/overLimitApi/1.0.0', '--file=test/resources/valid_api.json'])
@@ -130,7 +130,7 @@ describe('invalid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/orgNotExist/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/orgNotExist/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .reply(404, '{"code":404,"message":"{\\\"code\\\":404,\\\"message\\\":\\\"Object doesn\'t exist\\\"}"}')
     )
     .command([
@@ -152,7 +152,7 @@ describe('invalid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -173,7 +173,7 @@ describe('invalid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -200,7 +200,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -217,7 +217,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -238,7 +238,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -259,7 +259,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -291,7 +291,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.0&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.0&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -319,7 +319,7 @@ describe('valid api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=false&oas=3.0.0')
+      .post('/org/api?version=2.0.0&isPrivate=false&specification=openapi-3.0.0')
       .matchHeader('Content-Type', 'application/json')
       .reply(201)
     )
@@ -333,6 +333,49 @@ describe('valid api:create', () => {
     .it('runs api:create with json file', ctx => {
       expect(ctx.stdout).to.contains('Created API \'org/api\'')
     })
+
+  test
+      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+      .nock(`${shubUrl}/apis`, api => api
+          .get('/org/api')
+          .reply(404)
+      )
+      .nock(`${shubUrl}/apis`, api => api
+          .post('/org/api?version=2.0.0&isPrivate=false&specification=asyncapi-2.x.x')
+          .matchHeader('Content-Type', 'application/json')
+          .reply(201)
+      )
+      .stdout()
+      .command([
+        'api:create',
+        'org/api/2.0.0',
+        '--file=test/resources/valid_asyncapi.json',
+        '--visibility=public'
+      ])
+      .it('runs api:create with asyncapi json file', ctx => {
+        expect(ctx.stdout).to.contains('Created API \'org/api\'')
+      })
+  test
+      .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: shubUrl }))
+      .nock(`${shubUrl}/apis`, api => api
+          .get('/org/api')
+          .reply(404)
+      )
+      .nock(`${shubUrl}/apis`, api => api
+          .post('/org/api?version=2.0.0&isPrivate=false&specification=asyncapi-2.x.x')
+          .matchHeader('Content-Type', 'application/yaml')
+          .reply(201)
+      )
+      .stdout()
+      .command([
+        'api:create',
+        'org/api/2.0.0',
+        '--file=test/resources/valid_asyncapi.yaml',
+        '--visibility=public'
+      ])
+      .it('runs api:create with asyncapi yaml file', ctx => {
+        expect(ctx.stdout).to.contains('Created API \'org/api\'')
+      })
 })
 
 describe('valid create new version with api:create', () => {
@@ -347,7 +390,7 @@ describe('valid create new version with api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=1.0.1&isPrivate=true&oas=2.0')
+      .post('/org/api?version=1.0.1&isPrivate=true&specification=openapi-2.0')
       .matchHeader('Content-Type', 'application/yaml')
       .reply(201)
     )
@@ -368,7 +411,7 @@ describe('valid create new version with api:create', () => {
       .reply(404)
     )
     .nock(`${shubUrl}/apis`, api => api
-      .post('/org/api?version=2.0.0&isPrivate=false&oas=3.0.0')
+      .post('/org/api?version=2.0.0&isPrivate=false&specification=openapi-3.0.0')
       .reply(201)
     )
     .stdout()

--- a/test/resources/valid_asyncapi.json
+++ b/test/resources/valid_asyncapi.json
@@ -1,0 +1,104 @@
+{
+    "asyncapi": "2.4.0",
+    "info": {
+        "title": "Streetlights Kafka API",
+        "version": "1.0.0",
+        "description": ""
+    },
+    "channels": {
+        "smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured": {
+            "description": "The topic on which measured values may be produced and consumed.",
+            "parameters": {
+                "streetlightId": {
+                    "$ref": "#/components/parameters/streetlightId"
+                }
+            },
+            "publish": {
+                "summary": "Inform about environmental lighting conditions of a particular streetlight.",
+                "operationId": "receiveLightMeasurement",
+                "traits": [
+                    {
+                        "$ref": "#/components/operationTraits/kafka"
+                    }
+                ],
+                "message": {
+                    "$ref": "#/components/messages/lightMeasured"
+                }
+            }
+        }
+    },
+    "components": {
+        "messages": {
+            "lightMeasured": {
+                "name": "lightMeasured",
+                "title": "Light measured",
+                "summary": "Inform about environmental lighting conditions of a particular streetlight.",
+                "contentType": "application/json",
+                "traits": [
+                    {
+                        "$ref": "#/components/messageTraits/commonHeaders"
+                    }
+                ],
+                "payload": {
+                    "$ref": "#/components/schemas/lightMeasuredPayload"
+                }
+            }
+        },
+        "schemas": {
+            "lightMeasuredPayload": {
+                "type": "object",
+                "properties": {
+                    "lumens": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Light intensity measured in lumens."
+                    },
+                    "sentAt": {
+                        "$ref": "#/components/schemas/sentAt"
+                    }
+                }
+            },
+            "sentAt": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Date and time when the message was sent."
+            }
+        },
+        "parameters": {
+            "streetlightId": {
+                "description": "The ID of the streetlight.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
+        "messageTraits": {
+            "commonHeaders": {
+                "headers": {
+                    "type": "object",
+                    "properties": {
+                        "my-app-header": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100
+                        }
+                    }
+                }
+            }
+        },
+        "operationTraits": {
+            "kafka": {
+                "bindings": {
+                    "kafka": {
+                        "clientId": {
+                            "type": "string",
+                            "enum": [
+                                "my-app-id"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/resources/valid_asyncapi.yaml
+++ b/test/resources/valid_asyncapi.yaml
@@ -1,0 +1,67 @@
+asyncapi: '2.4.0'
+info:
+  title: Streetlights Kafka API
+  version: '1.0.0'
+  description: ""
+
+channels:
+  smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId:
+            type: string
+            enum: ['my-app-id']

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('@oclif/test')
 const { CLIError } = require('@oclif/errors') 
-const { parseDefinition } = require('../../src/utils/oas')
+const { parseDefinition } = require('../../src/utils/definitions')
 const { 
   isValidIdentifier, 
   getApiIdentifierArg, 


### PR DESCRIPTION
Closes #258  

This PR adds support for AsyncAPI definitions to the following commands:
- `api:create`
- `api:update`
- `domain:create`
- `domain:update`

## Proposed Changes
  - Add support for AsyncAPI to above commands.
  - Rename `oas` fields to `specification` to bring in line with current SwaggerHub terminology.
  - Rename `src/utils/oas` to `src/utils/definitions` to better convey what it is responsible for.

