### PR TITLE
Add fallback to old validation endpoint for api:validate

### DIFF
--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -31,9 +31,20 @@ class ValidateCommand extends BaseCommand {
     return this.executeHttp({
       execute: () => getApi([apiPath, 'standardization']),
       onResolve: pipeAsync(getResponseContent, JSON.parse),
+      onReject: () => this.getFallbackValidationResult(apiPath),
       options: {}
     })
   }
+
+  /* Required to support older on-prem installations */
+  getFallbackValidationResult(apiPath) {
+    return this.executeHttp({
+      execute: () => getApi([apiPath, 'validation']),
+      onResolve: pipeAsync(getResponseContent, JSON.parse),
+      options: {}
+    })
+  }
+
 }
 
 ValidateCommand.description = `get validation result for an API version


### PR DESCRIPTION
This PR adds a fallback to the `api:validate` command to support legacy On-Premise installs of SwaggerHub

