### PR TITLE
Add support for openapi-3.1.0 specification param

### DIFF
--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -6,9 +6,11 @@ const { errorMsg } = require('../template-strings')
 
 const specVersionToSpecification = specVersion => {
   if (/2.0$/.test(specVersion))
-      return 'openapi-2.0'
+    return 'openapi-2.0'
   if (/2.\d+.\d+$/.test(specVersion))
     return 'asyncapi-2.x.x'
+  if (/3.1.\d+$/.test(specVersion))
+    return 'openapi-3.1.0'
   return 'openapi-3.0.0'
 }
 

--- a/test/utils/definitions.test.js
+++ b/test/utils/definitions.test.js
@@ -2,9 +2,7 @@ const { expect, test } = require('@oclif/test')
 const { getSpecification } = require('../../src/utils/definitions')
 
 describe('getSpecification', () => {
-
   describe('should return `openapi-2.0`', () => {
-
     test.it('for `swagger: 2.0`', () => {
       const definition = { swagger: '2.0' }
   
@@ -15,7 +13,6 @@ describe('getSpecification', () => {
   })
 
   describe('should return `openapi-3.1.0`', () => {
-
     test.it('for `openapi: 3.1.0`', () => {
       const definition = { openapi: '3.1.0' }
   
@@ -34,7 +31,6 @@ describe('getSpecification', () => {
   })
   
   describe('should return `openapi-3.0.0`', () => {
-  
     test.it('for `openapi: 3.0.0`', () => {
       const definition = { openapi: '3.0.0' }
   
@@ -61,7 +57,6 @@ describe('getSpecification', () => {
   })
 
   describe('should return `asyncapi-2.x.x`', () => {
-
     test.it('for `asyncapi: 2.0.0`', () => {
       const definition = { asyncapi: '2.0.0' }
   
@@ -88,7 +83,6 @@ describe('getSpecification', () => {
   })
 
   describe('should default to `openapi-3.0.0`', () => {
-
     test.it('for `openapi: abcd`', () => {
       const definition = { openapi: 'abcd' }
   
@@ -121,5 +115,4 @@ describe('getSpecification', () => {
       expect(specification).to.equal('openapi-3.0.0')
     })
   })
-
 })

--- a/test/utils/definitions.test.js
+++ b/test/utils/definitions.test.js
@@ -1,0 +1,125 @@
+const { expect, test } = require('@oclif/test')
+const { getSpecification } = require('../../src/utils/definitions')
+
+describe('getSpecification', () => {
+
+  describe('should return `openapi-2.0`', () => {
+
+    test.it('for `swagger: 2.0`', () => {
+      const definition = { swagger: '2.0' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-2.0')
+    })
+  })
+
+  describe('should return `openapi-3.1.0`', () => {
+
+    test.it('for `openapi: 3.1.0`', () => {
+      const definition = { openapi: '3.1.0' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.1.0')
+    })
+  
+    test.it('for `openapi: 3.1.99`', () => {
+      const definition = { openapi: '3.1.99' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.1.0')
+    })
+  })
+  
+  describe('should return `openapi-3.0.0`', () => {
+  
+    test.it('for `openapi: 3.0.0`', () => {
+      const definition = { openapi: '3.0.0' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+  
+    test.it('for `openapi: 3.0.99`', () => {
+      const definition = { openapi: '3.0.99' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+  
+    test.it('for `openapi: 3.99.0`', () => {
+      const definition = { openapi: '3.99.0' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+  })
+
+  describe('should return `asyncapi-2.x.x`', () => {
+
+    test.it('for `asyncapi: 2.0.0`', () => {
+      const definition = { asyncapi: '2.0.0' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('asyncapi-2.x.x')
+    })
+
+    test.it('for `asyncapi: 2.6.99`', () => {
+      const definition = { asyncapi: '2.6.99' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('asyncapi-2.x.x')
+    })
+
+    test.it('for `asyncapi: 2.0.99`', () => {
+      const definition = { asyncapi: '2.0.99' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('asyncapi-2.x.x')
+    })
+  })
+
+  describe('should default to `openapi-3.0.0`', () => {
+
+    test.it('for `openapi: abcd`', () => {
+      const definition = { openapi: 'abcd' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+  
+    test.it('for `openapi: 4.7.9`', () => {
+      const definition = { openapi: '4.7.9' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+
+    test.it('for `openapi: 😄`', () => {
+      const definition = { openapi: '😄' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+
+    test.it('for `asyncapi: blah`', () => {
+      const definition = { asyncapi: 'blah' }
+  
+      const specification = getSpecification(definition)
+  
+      expect(specification).to.equal('openapi-3.0.0')
+    })
+  })
+
+})


### PR DESCRIPTION
This PR extends the `getSpecification` function to be able to differentiate between openapi-3.0.0 and openapi-3.1.0


