### PR TITLE
Fix exit codes for `api:validate` command

### DIFF
--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -14,7 +14,7 @@ class ValidateCommand extends BaseCommand {
     let hasCritical = false
     const validationResultsStr = validationResult.validation
           .map(err => {
-            if (err.severity.toLocaleUpperCase('en-US') === 'CRITICAL') hasCritical = true
+            if (err.severity.toUpperCase() === 'CRITICAL') hasCritical = true
             return `${err.line}: \t${err.severity} \t${err.description}`
           })
           .join('\n')

--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -14,7 +14,7 @@ class ValidateCommand extends BaseCommand {
     let hasCritical = false
     const validationResultsStr = validationResult.validation
           .map(err => {
-            if (err.severity === 'CRITICAL') hasCritical = true
+            if (err.severity.toLocaleUpperCase('en-US') === 'CRITICAL') hasCritical = true
             return `${err.line}: \t${err.severity} \t${err.description}`
           })
           .join('\n')

--- a/test/commands/api/validate.test.js
+++ b/test/commands/api/validate.test.js
@@ -5,7 +5,7 @@ const apiPath = 'example-org/example-api/example-ver'
 const heading = 'line \tseverity \tdescription\n\n'
 
 describe('invalid api:validate', () => {
-  const severity = 'CRITICAL',
+  const severity = 'critical',
     warningSeverity = 'WARNING',
     description = 'sample description',
     line = 10


### PR DESCRIPTION
This PR re-enables the exit codes for the `api:validate` command. 
