### PR TITLE
Add `-c/--fail-on-critical` flag to `api:validate` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,15 +332,19 @@ ARGUMENTS
   OWNER/API_NAME/[VERSION]  API Identifier
 
 OPTIONS
-  -h, --help  show CLI help
+  -c, --failOnCritical  Exit with error code 1 if there are critical standardization errors present
+  -h, --help            show CLI help
 
 DESCRIPTION
   When VERSION is not included in the argument, the default version will be validated.
   An error will occur if the API version does not exist.
+  If the flag `-c` or `--failOnCritical` is used and there are standardization
+  errors with `Critical` severity present, the command will exit with error code `1`.
 
 EXAMPLES
   swaggerhub api:validate organization/api/1.0.0
-  swaggerhub api:validate organization/api
+  swaggerhub api:validate -c organization/api/1.0.0
+  swaggerhub api:validate --fail-on-critical organization/api
 ```
 
 _See code: [src/commands/api/validate.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.6.5/src/commands/api/validate.js)_

--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ ARGUMENTS
   OWNER/API_NAME/[VERSION]  API Identifier
 
 OPTIONS
-  -c, --failOnCritical  Exit with error code 1 if there are critical standardization errors present
-  -h, --help            show CLI help
+  -c, --fail-on-critical  Exit with error code 1 if there are critical standardization errors present
+  -h, --help              show CLI help
 
 DESCRIPTION
   When VERSION is not included in the argument, the default version will be validated.

--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -1,3 +1,4 @@
+const { flags } = require('@oclif/command')
 const BaseCommand = require('../../support/command/base-command')
 const { getApiIdentifierArg } = require('../../support/command/parse-input')
 const { getApi } = require('../../requests/api')
@@ -6,7 +7,7 @@ const { getResponseContent } = require('../../support/command/handle-response')
 
 class ValidateCommand extends BaseCommand {
   async run() {
-    const { args } = this.parse(ValidateCommand)
+    const { args, flags } = this.parse(ValidateCommand)
     const apiPath = getApiIdentifierArg(args)
     const validPath = await this.ensureVersion(apiPath)
     const validationResult = await this.getValidationResult(validPath)
@@ -23,7 +24,7 @@ class ValidateCommand extends BaseCommand {
     }
     this.log(validationResultsStr)
     
-    if (hasCritical) this.exit(1)
+    if (hasCritical && flags.failOnCritical) this.exit(1)
     this.exit(0)
   }
 
@@ -50,11 +51,14 @@ class ValidateCommand extends BaseCommand {
 ValidateCommand.description = `get validation result for an API version
 When VERSION is not included in the argument, the default version will be validated.
 An error will occur if the API version does not exist.
+If the flag \`-c\` or \`--failOnCritical\` is used and there are standardization
+errors with \`Critical\` severity present, the command will exit with error code \`1\`.
 `
 
 ValidateCommand.examples = [
   'swaggerhub api:validate organization/api/1.0.0',
-  'swaggerhub api:validate organization/api'
+  'swaggerhub api:validate -c organization/api/1.0.0',
+  'swaggerhub api:validate --fail-on-critical organization/api'
 ]
 
 ValidateCommand.args = [{
@@ -63,6 +67,12 @@ ValidateCommand.args = [{
   description: 'API Identifier'
 }]
 
-ValidateCommand.flags = BaseCommand.flags
-
+ValidateCommand.flags = {
+  failOnCritical: flags.boolean({
+    char: 'c', 
+    description: 'Exit with error code 1 if there are critical standardization errors present',
+    default: false
+  }),
+  ...BaseCommand.flags
+}
 module.exports = ValidateCommand

--- a/src/commands/api/validate.js
+++ b/src/commands/api/validate.js
@@ -24,7 +24,7 @@ class ValidateCommand extends BaseCommand {
     }
     this.log(validationResultsStr)
     
-    if (hasCritical && flags.failOnCritical) this.exit(1)
+    if (hasCritical && flags['fail-on-critical']) this.exit(1)
     this.exit(0)
   }
 
@@ -68,7 +68,7 @@ ValidateCommand.args = [{
 }]
 
 ValidateCommand.flags = {
-  failOnCritical: flags.boolean({
+  'fail-on-critical': flags.boolean({
     char: 'c', 
     description: 'Exit with error code 1 if there are critical standardization errors present',
     default: false

--- a/test/commands/api/validate.test.js
+++ b/test/commands/api/validate.test.js
@@ -5,42 +5,6 @@ const apiPath = 'example-org/example-api/example-ver'
 const heading = 'line \tseverity \tdescription\n\n'
 
 describe('invalid api:validate', () => {
-  const severity = 'critical',
-    warningSeverity = 'WARNING',
-    description = 'sample description',
-    line = 10
-
-  test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${apiPath}/standardization`)
-    .reply(200, {
-      validation: [
-        { line, description, severity }
-      ]
-      })
-  )
-  .stdout()
-  .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
-  .exit(1)
-  .it('should return validation errors, one per line', ctx => {
-    expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
-  })
-
-  test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${apiPath}/standardization`)
-    .reply(200, {
-      validation: [
-        { line, description, severity: warningSeverity }
-      ]
-      })
-  )
-  .stdout()
-  .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
-  .exit(0)
-  .it('should return warning validation errors, one per line with zero exit code', ctx => {
-    expect(ctx.stdout).to.contains(`${heading}${line}: \t${warningSeverity} \t${description}`)
-  })
 
   test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
   .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
@@ -91,36 +55,157 @@ describe('invalid api:validate', () => {
   .it('not found returned when fetching default version of API')
 })
 
-describe('valid api:validation', () => {
-  test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${apiPath}/standardization`)
-    .reply(200, {
-      validation: []
+describe('valid api:validate', () => {
+  const description = 'sample description'
+  const line = 10
+
+  describe('with critical errors present', () => {
+    const severity = 'critical'
+
+    describe('without -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
       })
-  )
-  .stdout()
-  .command(['api:validate', apiPath])
-  .exit(0)
-  .it('should return empty result as there is no error', ctx => {
-    expect(ctx.stdout).to.contains('')
+    })
+
+    describe('with -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(1)
+      .it('should return validation errors, one per line, with exit code 1', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+      })
+    })
+    
+    describe('with --failOnCritical flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', '--failOnCritical', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(1)
+      .it('should return validation errors, one per line, with exit code 1', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+      })
+    })
   })
 
-  test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-  .nock('https://api.swaggerhub.com/apis', api => api
-    .get(`/${apiPath.substring(0, apiPath.lastIndexOf('/'))}/settings/default`)
-    .reply(200, { version: apiPath.substring(apiPath.lastIndexOf('/')+1) })
-  )
-  .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
-    .get(`/${apiPath}/standardization`)
-    .reply(200, {
-      validation: []
+  describe('without critical errors present', () => {
+    const severity = 'WARNING'
+
+    describe('without -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+      })
     })
-  )
-  .stdout()
-  .command(['api:validate', apiPath.substring(0, apiPath.lastIndexOf('/'))])
-  .exit(0)
-  .it('should resolve version and return empty result as there is no error', ctx => {
-    expect(ctx.stdout).to.contains('')
+
+    describe('with -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+      })
+    })
+
+    describe('with --failOnCritical flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+        .get(`/${apiPath}/standardization`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+          })
+      )
+      .stdout()
+      .command(['api:validate', '--failOnCritical', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+      })
+    })
+  })
+
+  describe('when no standardization errors present', () => {
+    test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+      .get(`/${apiPath}/standardization`)
+      .reply(200, {
+        validation: []
+        })
+    )
+    .stdout()
+    .command(['api:validate', apiPath])
+    .exit(0)
+    .it('should return empty result as there is no error', ctx => {
+      expect(ctx.stdout).to.contains('')
+    })
+
+    test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/apis', api => api
+      .get(`/${apiPath.substring(0, apiPath.lastIndexOf('/'))}/settings/default`)
+      .reply(200, { version: apiPath.substring(apiPath.lastIndexOf('/')+1) })
+    )
+    .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
+      .get(`/${apiPath}/standardization`)
+      .reply(200, {
+        validation: []
+      })
+    )
+    .stdout()
+    .command(['api:validate', apiPath.substring(0, apiPath.lastIndexOf('/'))])
+    .exit(0)
+    .it('should resolve version and return empty result as there is no error', ctx => {
+      expect(ctx.stdout).to.contains('')
+    })
   })
 })

--- a/test/commands/api/validate.test.js
+++ b/test/commands/api/validate.test.js
@@ -98,7 +98,7 @@ describe('valid api:validate', () => {
       })
     })
     
-    describe('with --failOnCritical flag', () => {
+    describe('with --fail-on-critical flag', () => {
       test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
       .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
         .get(`/${apiPath}/standardization`)
@@ -109,7 +109,7 @@ describe('valid api:validate', () => {
           })
       )
       .stdout()
-      .command(['api:validate', '--failOnCritical', apiPath]) // swaggerhub api:validate o/a/v
+      .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
         expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
@@ -156,7 +156,7 @@ describe('valid api:validate', () => {
       })
     })
 
-    describe('with --failOnCritical flag', () => {
+    describe('with --fail-on-critical flag', () => {
       test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
       .nock('https://api.swaggerhub.com/apis', { reqheaders: { Accept: 'application/json' } }, api => api
         .get(`/${apiPath}/standardization`)
@@ -167,7 +167,7 @@ describe('valid api:validate', () => {
           })
       )
       .stdout()
-      .command(['api:validate', '--failOnCritical', apiPath]) // swaggerhub api:validate o/a/v
+      .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
         expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)


### PR DESCRIPTION
This PR adds the `-c/--fail-on-critical` flag to the `api:validate` command. 
When this flag is present, if there are critical standardization errors present in the referenced definition, the CLI with exit with error code `1`.
Also slight refactor of the existing tests for `api:validate` command.

