### PR TITLE
Update Docker base image to node 18

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 output=$(/cli/bin/run $*); status=$?;
-echo "::set-output name=response::
-$output"
+echo "response=$output" >> $GITHUB_OUTPUT
 exit $status

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:18-alpine
 WORKDIR /cli
 COPY package*.json ./
 COPY ./bin ./bin


### PR DESCRIPTION
This PR updates the base node Docker image from using Node.js 12, which support was dropped as part of the swagger-cli 0.7.0 release. Now using the Node.js 18 as the base image.

Additionally replacing the usage of `set-output` which has been deprecated:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Resolves #290 