### PR TITLE
Update versions in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,9 +15,9 @@ assignees: ''
 
 ### Q&A (please complete the following information)
  - CLI version: [e.g. 1.0.0]
- - OS: [e.g. macOS Catalina]
- - Node.js version: [e.g. 12.16.3]
- - SwaggerHub version if On-Premise: [e.g. 1.24.0-52]
+ - OS: [e.g. macOS Ventura]
+ - Node.js version: [e.g. 18.15.0]
+ - SwaggerHub version if On-Premise: [e.g. 2.3.0+111]
 
 ### Describe the bug you're encountering
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/action/README.md
+++ b/.github/action/README.md
@@ -29,14 +29,13 @@ on:
       
 env:
   SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
-  SWAGGERHUB_URL: ${{ secrets.SWAGGERHUB_URL }}
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Update SwaggerHub
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Call CLI
       uses: smartbear/swaggerhub-cli@pr_demo
       with:
@@ -57,7 +56,7 @@ jobs:
     name: Update SwaggerHub
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Call CLI
       uses: smartbear/swaggerhub-cli@pr_demo
       with:

--- a/.github/action/README.md
+++ b/.github/action/README.md
@@ -50,6 +50,7 @@ name: Push API
 on: [release]  
 env:
   SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+  SWAGGERHUB_URL: ${{ secrets.SWAGGERHUB_URL }}
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updating the documentation to use current versions. In particular the GitHub action example is often copy-pasted so it's good to suggest the latest version of actions/checkout. 
I've move the example of setting `SWAGGERHUB_URL` to the second example so that the first example is simpler.