### PR TITLE
Fix mutil-line output for GH Action

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 output=$(/cli/bin/run $*); status=$?;
-echo "response=$output" >> $GITHUB_OUTPUT
+
+delimiter="$(openssl rand -hex 8)"
+echo "response<<${delimiter}" >> "${GITHUB_OUTPUT}"
+echo "${output}" >> "${GITHUB_OUTPUT}"
+echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+
 exit $status


### PR DESCRIPTION
This PR fixes the output for the swaggerhub-cli GitHub Action as per [this solution](https://github.com/orgs/community/discussions/26288#discussioncomment-3876281).
This fix will work for single-line and multi-line responses.

Fixes #293 

* [x] I have added the appropriate label to my PR