### PR TITLE
Use example from docs to fix GH Action

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 output=$(/cli/bin/run $*); status=$?;
 
-delimiter="$(uuidgen)"
-echo "response<<${delimiter}" >> "${GITHUB_OUTPUT}"
-echo "${output}" >> "${GITHUB_OUTPUT}"
-echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+echo "response<<$EOF" >> $GITHUB_OUTPUT
+echo $output >> $GITHUB_OUTPUT
+echo "$EOF" >> $GITHUB_OUTPUT
 
 exit $status


### PR DESCRIPTION
This PR uses the example from docs to fix GH Action as per https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string

* [x] I have added the appropriate label to my PR