### PR TITLE
Add api:validate:local command and refactor shared functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ ARGUMENTS
 FLAGS
   -c, --fail-on-critical  Exit with error code 1 if there are critical standardization errors present
   -h, --help              Show CLI help.
-  -j, --to-json           Print output in JSON instead of table format
+  -j, --json           Print output in JSON instead of table format
 
 DESCRIPTION
   Get validation result for an API version
@@ -407,7 +407,7 @@ FLAGS
   -c, --fail-on-critical      Exit with error code 1 if there are critical standardization errors present
   -f, --file=<value>          (required) Path of API definition file to run scan against
   -h, --help                  Show CLI help.
-  -j, --to-json               Print output in JSON instead of table format
+  -j, --json               Print output in JSON instead of table format
   -o, --organization=<value>  (required) Which organization's standardization settings to use for linting the target
                               definition
 
@@ -420,7 +420,7 @@ DESCRIPTION
 EXAMPLES
   $ swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml
 
-  $ swaggerhub api:validate-local --fail-on-critical --to-json --organization myOrg --file ./my-api/json
+  $ swaggerhub api:validate-local --fail-on-critical --json --organization myOrg --file ./my-api/json
 ```
 
 _See code: [src/commands/api/validate/local.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate/local.js)_

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ ARGUMENTS
 FLAGS
   -c, --fail-on-critical  Exit with error code 1 if there are critical standardization errors present
   -h, --help              Show CLI help.
-  -j, --json           Print output in JSON instead of table format
+  -j, --json              Print output in JSON instead of table format
 
 DESCRIPTION
   Get validation result for an API version
@@ -388,9 +388,9 @@ DESCRIPTION
 EXAMPLES
   $ swaggerhub api:validate organization/api/1.0.0
 
-  $ swaggerhub api:validate -c organization/api/1.0.0
+  $ swaggerhub api:validate -c -j organization/api/1.0.0
 
-  $ swaggerhub api:validate --fail-on-critical organization/api
+  $ swaggerhub api:validate --fail-on-critical --json organization/api
 ```
 
 _See code: [src/commands/api/validate/index.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate/index.js)_
@@ -407,7 +407,7 @@ FLAGS
   -c, --fail-on-critical      Exit with error code 1 if there are critical standardization errors present
   -f, --file=<value>          (required) Path of API definition file to run scan against
   -h, --help                  Show CLI help.
-  -j, --json               Print output in JSON instead of table format
+  -j, --json                  Print output in JSON instead of table format
   -o, --organization=<value>  (required) Which organization's standardization settings to use for linting the target
                               definition
 
@@ -418,9 +418,9 @@ DESCRIPTION
 
 
 EXAMPLES
-  $ swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml
+  $ swaggerhub api:validate:local -o myOrg -f ./my-api.yaml -c -j 
 
-  $ swaggerhub api:validate-local --fail-on-critical --json --organization myOrg --file ./my-api/json
+  $ swaggerhub api:validate:local --organization myOrg --file ./my-api/json --fail-on-critical --json
 ```
 
 _See code: [src/commands/api/validate/local.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate/local.js)_

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ USAGE
 * [`swaggerhub api:unpublish OWNER/API_NAME/VERSION`](#swaggerhub-apiunpublish)
 * [`swaggerhub api:update OWNER/API_NAME/[VERSION]`](#swaggerhub-apiupdate)
 * [`swaggerhub api:validate OWNER/API_NAME/[VERSION]`](#swaggerhub-apivalidate)
+* [`swaggerhub api:validate:local`](#swaggerhub-apivalidatelocal)
 * [`swaggerhub configure`](#swaggerhub-configure)
 * [`swaggerhub domain:create OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domaincreate)
 * [`swaggerhub domain:delete OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domaindelete)
@@ -362,11 +363,11 @@ _See code: [src/commands/api/update.js](https://github.com/SmartBear/swaggerhub-
 
 ## `swaggerhub api:validate`
 
-get validation result for an API version
+Get validation result for an API version
 
 ```
 USAGE
-  $ swaggerhub api:validate OWNER/API_NAME/[VERSION] [-h] [-c]
+  $ swaggerhub api:validate OWNER/API_NAME/[VERSION] [-h] [-c] [-j]
 
 ARGUMENTS
   OWNER/API_NAME/[VERSION]  API to fetch validation errors for from Swaggerhub
@@ -374,9 +375,10 @@ ARGUMENTS
 FLAGS
   -c, --fail-on-critical  Exit with error code 1 if there are critical standardization errors present
   -h, --help              Show CLI help.
+  -j, --to-json           Print output in JSON instead of table format
 
 DESCRIPTION
-  get validation result for an API version
+  Get validation result for an API version
   When VERSION is not included in the argument, the default version will be validated.
   An error will occur if the API version does not exist.
   If the flag `-c` or `--failOnCritical` is used and there are standardization
@@ -391,7 +393,37 @@ EXAMPLES
   $ swaggerhub api:validate --fail-on-critical organization/api
 ```
 
-_See code: [src/commands/api/validate.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate.js)_
+_See code: [src/commands/api/validate/index.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate/index.js)_
+
+## `swaggerhub api:validate:local`
+
+Runs a scan against a local API definition using the organization's standardization configuration on SwaggerHub.
+
+```
+USAGE
+  $ swaggerhub api:validate:local -f <value> -o <value> [-h] [-c] [-j]
+
+FLAGS
+  -c, --fail-on-critical      Exit with error code 1 if there are critical standardization errors present
+  -f, --file=<value>          (required) Path of API definition file to run scan against
+  -h, --help                  Show CLI help.
+  -j, --to-json               Print output in JSON instead of table format
+  -o, --organization=<value>  (required) Which organization's standardization settings to use for linting the target
+                              definition
+
+DESCRIPTION
+  Runs a scan against a local API definition using the organization's standardization configuration on SwaggerHub.
+  If the flag `-c` or `--failOnCritical` is used and there are standardization
+  errors with `Critical` severity present, the command will exit with error code `1`.
+
+
+EXAMPLES
+  $ swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml
+
+  $ swaggerhub api:validate-local --fail-on-critical --to-json --organization myOrg --file ./my-api/json
+```
+
+_See code: [src/commands/api/validate/local.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.7.2/src/commands/api/validate/local.js)_
 
 ## `swaggerhub configure`
 
@@ -646,7 +678,7 @@ DESCRIPTION
   Display help for swaggerhub.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.8/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.10/src/commands/help.ts)_
 
 ## `swaggerhub integration:create`
 
@@ -798,10 +830,13 @@ List installed plugins.
 
 ```
 USAGE
-  $ swaggerhub plugins [--core]
+  $ swaggerhub plugins [--json] [--core]
 
 FLAGS
   --core  Show core plugins.
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 DESCRIPTION
   List installed plugins.
@@ -810,7 +845,7 @@ EXAMPLES
   $ swaggerhub plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/index.ts)_
 
 ## `swaggerhub plugins:install`
 
@@ -875,7 +910,7 @@ EXAMPLES
   $ swaggerhub plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/inspect.ts)_
 
 ## `swaggerhub plugins:install`
 
@@ -915,7 +950,7 @@ EXAMPLES
   $ swaggerhub plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/install.ts)_
 
 ## `swaggerhub plugins:link`
 
@@ -944,7 +979,7 @@ EXAMPLES
   $ swaggerhub plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/link.ts)_
 
 ## `swaggerhub plugins:uninstall`
 
@@ -992,7 +1027,7 @@ ALIASES
   $ swaggerhub plugins:remove
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/uninstall.ts)_
 
 ## `swaggerhub plugins:uninstall`
 
@@ -1033,7 +1068,7 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v2.4.3/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v3.1.5/src/commands/plugins/update.ts)_
 
 ## `swaggerhub project:api:add`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -53,28 +66,36 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
+      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/core": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
-      "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
+      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.7",
-        "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.9",
-        "@babel/types": "^7.12.7",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.22.5",
+        "@babel/helpers": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -84,515 +105,232 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/generator": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/parser": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/traverse": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
-      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+    "node_modules/@babel/generator": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
+      "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.7"
+        "@babel/types": "^7.22.5",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
+      "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.5",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.5"
-      }
-    },
-    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
+      "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-simple-access": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/generator": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/parser": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
+        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
-      "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.7"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.1",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/generator": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/parser": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/traverse": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
+      "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
+      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
+      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/generator": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.12.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/parser": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/traverse": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -660,6 +398,91 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
+      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
+      "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/types": "^7.22.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -836,10 +659,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -920,9 +766,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.7.tgz",
-      "integrity": "sha512-WTZUFgANYGyHQOmGc2YsczEdqdlG2/ZEfqksHnuYbz3egozpka/R9LrFwNfWPZETi9ydzcjDWwJKUGQmJG3ixA==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.8.tgz",
+      "integrity": "sha512-21U+WDgyb/xnefx9DWZhBHj5TlloZZiA1dVAE1Y8FGSAJwdArI4HqaNgp99BcyuaeX5XOz1tPeXoeB/j8uADcQ==",
       "dependencies": {
         "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
@@ -1514,6 +1360,38 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "node_modules/browserslist": {
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
+        "node-releases": "^2.0.12",
+        "update-browserslist-db": "^1.0.11"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1577,6 +1455,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001508",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -1954,6 +1852,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.441",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.441.tgz",
+      "integrity": "sha512-LlCgQ8zgYZPymf5H4aE9itwiIWH4YlCiv1HFLmmcBeFYi5E+3eaIFnjHzYtcFQbaKfAW+CqZ9pgxo33DZuoqPg==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2617,9 +2521,9 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -3307,9 +3211,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3352,18 +3256,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -3481,9 +3384,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -4018,6 +3921,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6944,21 +6853,6 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/nyc/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/nyc/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nyc/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6981,20 +6875,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -7281,6 +7161,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -7954,15 +7840,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -8197,7 +8074,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8340,6 +8217,36 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8355,13 +8262,12 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -8431,32 +8337,6 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dependencies": {
         "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/src/commands/api/validate/index.js
+++ b/src/commands/api/validate/index.js
@@ -50,8 +50,8 @@ errors with \`Critical\` severity present, the command will exit with error code
 
 ValidateCommand.examples = [
   'swaggerhub api:validate organization/api/1.0.0',
-  'swaggerhub api:validate -c organization/api/1.0.0',
-  'swaggerhub api:validate --fail-on-critical organization/api'
+  'swaggerhub api:validate -c -j organization/api/1.0.0',
+  'swaggerhub api:validate --fail-on-critical --json organization/api'
 ]
 
 ValidateCommand.args = {

--- a/src/commands/api/validate/index.js
+++ b/src/commands/api/validate/index.js
@@ -1,12 +1,12 @@
-const { Args, Flags } = require('@oclif/core')
-const BaseCommand = require('../../support/command/base-command')
-const { getApiIdentifierArg } = require('../../support/command/parse-input')
-const { getApi } = require('../../requests/api')
-const { pipeAsync } = require('../../utils/general')
-const { getResponseContent } = require('../../support/command/handle-response')
-const { isOnPrem } = require('../../support/isOnPrem')
+const { Args } = require('@oclif/core')
+const BaseValidateCommand = require('../../../support/command/base-validate-command')
+const { getApiIdentifierArg } = require('../../../support/command/parse-input')
+const { getApi } = require('../../../requests/api')
+const { pipeAsync } = require('../../../utils/general')
+const { getResponseContent } = require('../../../support/command/handle-response')
+const { isOnPrem } = require('../../../support/isOnPrem')
 
-class ValidateCommand extends BaseCommand {
+class ValidateCommand extends BaseValidateCommand {
   async run() {
     const { args, flags } = await this.parse(ValidateCommand)
     const apiPath = getApiIdentifierArg(args)
@@ -17,21 +17,8 @@ class ValidateCommand extends BaseCommand {
     if (validationResult.validation.length === 0 && isOnPrem()) {
       validationResult = await this.getFallbackValidationResult(validPath)
     }
-    // eslint-disable-next-line immutable/no-let
-    let hasCritical = false
-    const validationResultsStr = validationResult.validation
-          .map(err => {
-            if (err.severity.toUpperCase() === 'CRITICAL') hasCritical = true
-            return `${err.line}: \t${err.severity} \t${err.description}`
-          })
-          .join('\n')
-    if (validationResult.validation.length) {
-      this.log('line \tseverity \tdescription\n')
-    }
-    this.log(validationResultsStr)
-    
-    if (hasCritical && flags['fail-on-critical']) this.exit(1)
-    this.exit(0)
+    this.printValidationOutput(flags, validationResult)
+    this.exitWithCode(flags, validationResult)
   }
 
   getValidationResult(apiPath) {
@@ -52,10 +39,9 @@ class ValidateCommand extends BaseCommand {
       options: {}
     })
   }
-
 }
 
-ValidateCommand.description = `get validation result for an API version
+ValidateCommand.description = `Get validation result for an API version
 When VERSION is not included in the argument, the default version will be validated.
 An error will occur if the API version does not exist.
 If the flag \`-c\` or \`--failOnCritical\` is used and there are standardization
@@ -76,11 +62,6 @@ ValidateCommand.args = {
 }
 
 ValidateCommand.flags = {
-  'fail-on-critical': Flags.boolean({
-    char: 'c', 
-    description: 'Exit with error code 1 if there are critical standardization errors present',
-    default: false
-  }),
-  ...BaseCommand.flags
+  ...BaseValidateCommand.flags
 }
 module.exports = ValidateCommand

--- a/src/commands/api/validate/local.js
+++ b/src/commands/api/validate/local.js
@@ -1,0 +1,60 @@
+const { Flags } = require('@oclif/core')
+const BaseValidateCommand = require('../../../support/command/base-validate-command')
+const { pipeAsync } = require('../../../utils/general')
+const { getResponseContent } = require('../../../support/command/handle-response')
+const { postStandardization } = require('../../../requests/standardization')
+const { parseDefinition, getSpecification, getVersion } = require('../../../utils/definitions')
+const { readFileSync } = require('fs-extra')
+
+class ValidateLocalCommand extends BaseValidateCommand {
+  async run() {
+    const { flags } = await this.parse(ValidateLocalCommand)
+    this.validateDefinition(flags['file'])
+    const definition = readFileSync(flags['file'])
+    const validationResult = await this.getValidationResult(flags['organization'], definition)
+    this.printValidationOutput(flags, validationResult)
+    this.exitWithCode(flags, validationResult)
+  }
+
+  // Rudimentary checks to check that file is
+  // at least an OpenAPI/AsyncAPI definition
+  // and is valid yaml/json
+  validateDefinition(pathToFile) {
+    const definition = parseDefinition(pathToFile)
+    getSpecification(definition)
+    getVersion(definition)
+  }
+
+  getValidationResult(orgName, body) {
+    return this.executeHttp({
+      execute: () => postStandardization([orgName, 'scan'], body),
+      onResolve: pipeAsync(getResponseContent, JSON.parse),
+      options: {}
+    })
+  }
+}
+
+ValidateLocalCommand.description = `Runs a scan against a local API definition using the organization's standardization configuration on SwaggerHub.
+If the flag \`-c\` or \`--failOnCritical\` is used and there are standardization
+errors with \`Critical\` severity present, the command will exit with error code \`1\`.
+`
+
+ValidateLocalCommand.examples = [
+  'swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml',
+  'swaggerhub api:validate-local --fail-on-critical --to-json --organization myOrg --file ./my-api/json',
+]
+
+ValidateLocalCommand.flags = {
+  'file': Flags.string({
+    char: 'f',
+    description: 'Path of API definition file to run scan against',
+    required: true
+  }),
+  'organization': Flags.string({
+    char: 'o',
+    description: 'Which organization\'s standardization settings to use for linting the target definition',
+    required: true
+  }),
+  ...BaseValidateCommand.flags
+}
+module.exports = ValidateLocalCommand

--- a/src/commands/api/validate/local.js
+++ b/src/commands/api/validate/local.js
@@ -41,7 +41,7 @@ errors with \`Critical\` severity present, the command will exit with error code
 
 ValidateLocalCommand.examples = [
   'swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml',
-  'swaggerhub api:validate-local --fail-on-critical --to-json --organization myOrg --file ./my-api/json',
+  'swaggerhub api:validate-local --fail-on-critical --json --organization myOrg --file ./my-api/json',
 ]
 
 ValidateLocalCommand.flags = {

--- a/src/commands/api/validate/local.js
+++ b/src/commands/api/validate/local.js
@@ -40,8 +40,8 @@ errors with \`Critical\` severity present, the command will exit with error code
 `
 
 ValidateLocalCommand.examples = [
-  'swaggerhub api:validate-local -c -j -o myOrg -f ./my-api.yaml',
-  'swaggerhub api:validate-local --fail-on-critical --json --organization myOrg --file ./my-api/json',
+  'swaggerhub api:validate:local -o myOrg -f ./my-api.yaml -c -j ',
+  'swaggerhub api:validate:local --organization myOrg --file ./my-api/json --fail-on-critical --json',
 ]
 
 ValidateLocalCommand.flags = {

--- a/src/requests/standardization.js
+++ b/src/requests/standardization.js
@@ -1,0 +1,20 @@
+const config = require('../config')
+const http = require('../support/http')
+const { hasJsonStructure } = require('../utils/general')
+
+const postStandardization = (pathParams, body) => {
+    const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
+    const isJson = hasJsonStructure(body)
+
+    return http({
+        url: [SWAGGERHUB_URL, 'standardization', ...pathParams],
+        auth: SWAGGERHUB_API_KEY,
+        contentType: isJson ? 'json' : 'yaml',
+        method: 'POST',
+        body
+    })
+}
+
+module.exports = {
+    postStandardization
+}

--- a/src/support/command/base-validate-command.js
+++ b/src/support/command/base-validate-command.js
@@ -10,7 +10,7 @@ class BaseValidateCommand extends BaseCommand {
     }
 
     printValidationOutput(flags, validationResult) {
-        if (validationResult.validation.length && !flags['to-json']) {
+        if (validationResult.validation.length && !flags['json']) {
             ux.table(validationResult.validation, {
                 line: {},
                 severity: {},
@@ -30,7 +30,7 @@ BaseValidateCommand.flags = {
         description: 'Exit with error code 1 if there are critical standardization errors present',
         default: false
     }),
-    'to-json': Flags.boolean({
+    'json': Flags.boolean({
         char: 'j',
         description: 'Print output in JSON instead of table format',
         default: false

--- a/src/support/command/base-validate-command.js
+++ b/src/support/command/base-validate-command.js
@@ -1,0 +1,40 @@
+const { Flags, ux } = require('@oclif/core')
+const BaseCommand = require('../../support/command/base-command')
+
+class BaseValidateCommand extends BaseCommand {
+
+    exitWithCode(flags, validationResult) {
+        const hasCritical = validationResult.validation.some(err => err.severity.toUpperCase() === 'CRITICAL')
+        const exitCode = hasCritical && flags['fail-on-critical'] ? 1 : 0
+        this.exit(exitCode)
+    }
+
+    printValidationOutput(flags, validationResult) {
+        if (validationResult.validation.length && !flags['to-json']) {
+            ux.table(validationResult.validation, {
+                line: {},
+                severity: {},
+                description: {},
+            }, {
+                printLine: this.log.bind(this)
+            })
+        } else {
+            this.log(JSON.stringify(validationResult, null, 2))
+        }
+    }
+}
+
+BaseValidateCommand.flags = {
+    'fail-on-critical': Flags.boolean({
+        char: 'c',
+        description: 'Exit with error code 1 if there are critical standardization errors present',
+        default: false
+    }),
+    'to-json': Flags.boolean({
+        char: 'j',
+        description: 'Print output in JSON instead of table format',
+        default: false
+    }),
+    ...BaseCommand.flags
+}
+module.exports = BaseValidateCommand

--- a/test/commands/api/validate/index.test.js
+++ b/test/commands/api/validate/index.test.js
@@ -2,8 +2,7 @@ const config = require('../../../../src/config')
 const { expect, test } = require('@oclif/test')
 
 const apiPath = 'example-org/example-api/example-ver'
-const heading = ' Line Severity Description        \n' +
-    ' ──── ──────── ────────────────── \n'
+const heading = ' Line Severity Description        \n ──── ──────── ────────────────── \n'
 
 describe('invalid api:validate', () => {
 

--- a/test/commands/api/validate/index.test.js
+++ b/test/commands/api/validate/index.test.js
@@ -1,8 +1,9 @@
-const config = require('../../../src/config')
+const config = require('../../../../src/config')
 const { expect, test } = require('@oclif/test')
 
 const apiPath = 'example-org/example-api/example-ver'
-const heading = 'line \tseverity \tdescription\n\n'
+const heading = ' Line Severity Description        \n' +
+    ' ──── ──────── ────────────────── \n'
 
 describe('invalid api:validate', () => {
 
@@ -94,7 +95,7 @@ describe('valid api:validate for swaggerhub on-premise <= 2.4.1', () => {
   .command(['api:validate', apiPath])
   .exit(0)
   .it('should fall back to legacy /validation endpoint and return errors', ctx => {
-    expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+    expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
   })
 })
 
@@ -119,7 +120,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
       })
     })
 
@@ -137,7 +138,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
       })
     })
     
@@ -155,7 +156,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
       })
     })
   })
@@ -177,7 +178,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -195,7 +196,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -213,7 +214,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading}${line}: \t${severity} \t${description}`)
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
   })

--- a/test/commands/api/validate/local.test.js
+++ b/test/commands/api/validate/local.test.js
@@ -1,0 +1,221 @@
+const { test, expect } = require('@oclif/test')
+const config = require('../../../../src/config')
+
+const orgName = 'example-org'
+const apiPath = './test/resources/valid_api.yaml'
+const jsonApiPath = './test/resources/valid_api.json'
+const heading = ' Line Severity Description        \n' +
+  ' ──── ──────── ────────────────── \n'
+
+describe('invalid api:validate:local command issues', () => {
+  test
+  .command(['api:validate:local'])
+  .exit(2)
+  .it('runs api:validate:local with no flags provided')
+
+  test
+  .command(['api:create', '-f', apiPath])
+  .exit(2)
+  .it('runs api:create with no required --organization flag')
+
+  test
+  .command(['api:create', '-o', orgName])
+  .exit(2)
+  .it('runs api:create with no required --file flag')
+})
+
+describe('invalid api:validate:local file issues', () => {
+  test
+  .command(['api:validate:local', '-o', orgName, '-f', 'test/resources/missing_file.yaml'])
+  .catch(ctx => {
+    expect(ctx.message).to.contain('File \'test/resources/missing_file.yaml\' not found')
+  })
+  .it('runs api:create with file not found')
+
+  test
+  .command(['api:validate:local', '-o', orgName, '-f', 'test/resources/invalid_format.yaml'])
+  .catch(ctx => {
+    expect(ctx.message).to.contain('There was a problem with parsing test/resources/invalid_format.yaml.')
+  })
+  .it('runs api:create with incorrectly formatted file')
+
+  test
+  .command(['api:validate:local', '-o', orgName, '-f', 'test/resources/missing_oas_version.yaml'])
+  .catch(ctx => {
+    expect(ctx.message).to.contain('Cannot determine specification from file')
+  })
+  .it('runs api:create with file missing specification')
+
+  test
+  .command(['api:validate:local', '-o', orgName, '-f', 'test/resources/missing_version.yaml'])
+  .catch(ctx => {
+    expect(ctx.message).to.contain('Cannot determine version from file')
+  })
+  .it('runs api:create with file missing version')
+})
+
+describe('valid api:validate:local', () => {
+  const description = 'sample description'
+  const line = 10
+
+  describe('with critical errors present', () => {
+    const severity = 'critical'
+
+    describe('without -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .matchHeader('Content-Type', 'application/yaml')
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command([
+        'api:validate:local', '-o', orgName, '-f', apiPath
+      ])
+      .exit(0)
+      .it('should return validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+      })
+    })
+
+    describe('with -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command([
+        'api:validate:local', '-c', '-o', orgName, '-f', apiPath, '-c'
+      ]) // swaggerhub api:validate o/a/v
+      .exit(1)
+      .it('should return validation errors, one per line, with exit code 1', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+      })
+    })
+
+    describe('with --fail-on-critical flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command([
+        'api:validate:local', '--fail-on-critical', '-o', orgName, '-f', apiPath, '--fail-on-critical'
+      ]) // swaggerhub api:validate o/a/v
+      .exit(1)
+      .it('should return validation errors, one per line, with exit code 1', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+      })
+    })
+  })
+
+  describe('without critical errors present', () => {
+    const severity = 'WARNING'
+
+    describe('without -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command(['api:validate:local', '-o', orgName, '-f', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+      })
+    })
+
+    describe('with -c flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command(['api:validate:local', '-c', '-o', orgName, '-f', apiPath]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+      })
+    })
+
+    describe('with --fail-on-critical flag', () => {
+      test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+      .nock('https://api.swaggerhub.com/standardization', api => api
+        .post(`/${orgName}/scan`)
+        .reply(200, {
+          validation: [
+            { line, description, severity }
+          ]
+        })
+      )
+      .stdout()
+      .command([
+        'api:validate:local', '--fail-on-critical', '-o', orgName, '-f', apiPath
+      ]) // swaggerhub api:validate o/a/v
+      .exit(0)
+      .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+      })
+    })
+  })
+
+  describe('when no standardization errors present', () => {
+    test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/standardization', api => api
+      .post(`/${orgName}/scan`)
+      .reply(200, {
+        validation: []
+      })
+    )
+    .stdout()
+    .command(['api:validate:local', '-o', orgName, '-f', apiPath])
+    .exit(0)
+    .it('should return empty result as there is no error', ctx => {
+      expect(ctx.stdout).to.not.contains(heading)
+    })
+  })
+
+  describe('when sending a JSON file', () => {
+    const severity = 'WARNING'
+
+    test.stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+    .nock('https://api.swaggerhub.com/standardization', api => api
+      .post(`/${orgName}/scan`)
+      .reply(200, {
+        validation: [
+          { line, description, severity }
+        ]
+      })
+    )
+    .stdout()
+    .command(['api:validate:local', '-o', orgName, '-f', jsonApiPath])
+    .exit(0)
+    .it('should return warning validation errors, one per line, with exit code 0', ctx => {
+      expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+    })
+  })
+})

--- a/test/commands/api/validate/local.test.js
+++ b/test/commands/api/validate/local.test.js
@@ -4,8 +4,7 @@ const config = require('../../../../src/config')
 const orgName = 'example-org'
 const apiPath = './test/resources/valid_api.yaml'
 const jsonApiPath = './test/resources/valid_api.json'
-const heading = ' Line Severity Description        \n' +
-  ' ──── ──────── ────────────────── \n'
+const heading = ' Line Severity Description        \n ──── ──────── ────────────────── \n'
 
 describe('invalid api:validate:local command issues', () => {
   test


### PR DESCRIPTION
This PR:
- Adds a new `api:validate:local` command that takes an API definition from the local filesystem and runs a standardization scan on it using the given organization's standardization configuration on SwaggerHub.
- Adds support for json output to the `api:validate/api:validate:local` commands as requested by https://github.com/SmartBear/swaggerhub-cli/issues/110#issuecomment-718302230
- Updates the output from the `api:validate/api:validate:local` commands to use `ux.table` to bring it in line with the tables in the rest of the codebase

* [x] I have added the appropriate label to my PR