### PR TITLE
Add dependency groups for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      oclif:
+        patterns:
+        - '@oclif*'
+      dev-dependencies:
+        dependency-type: 'development'
+      


### PR DESCRIPTION
This PR adds groups for dependabot to group together the created PRs for:
- all `@oclif` dependencies
- all dev dependencies

* [x] I have added the appropriate label to my PR