### PR TITLE
Chore/Adding manual dispatch and CRON to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+  schedule:
+    - cron: '30 5 * * 2'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
As discussed with Security team, it would be good to have manual trigger for CodeQL scan (and CRON job for repos that are released rarely).

* [X] I have added the appropriate label to my PR