### PR TITLE
SWG-9025 Fetch organization standardization configuration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ USAGE
 * [`swaggerhub api:unpublish OWNER/API_NAME/VERSION`](#swaggerhub-apiunpublish)
 * [`swaggerhub api:update OWNER/API_NAME/[VERSION]`](#swaggerhub-apiupdate)
 * [`swaggerhub api:validate OWNER/API_NAME/[VERSION]`](#swaggerhub-apivalidate)
+* [`swaggerhub api:validate:download-rules OWNER`](#swaggerhub-apivalidatedownload-rules)
 * [`swaggerhub api:validate:local`](#swaggerhub-apivalidatelocal)
 * [`swaggerhub configure`](#swaggerhub-configure)
 * [`swaggerhub domain:create OWNER/DOMAIN_NAME/[VERSION]`](#swaggerhub-domaincreate)
@@ -424,6 +425,37 @@ EXAMPLES
 ```
 
 _See code: [src/commands/api/validate/local.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.8.1/src/commands/api/validate/local.js)_
+
+## `swaggerhub api:validate:download-rules`
+
+Get existing SwaggerHub's organization standardization ruleset.
+
+```
+USAGE
+  $ swaggerhub api:validate:download-rules OWNER [-s] [-d] [-h]
+
+ARGUMENTS
+  OWNER  Which organization standardization rules to fetch from SwaggerHub
+
+FLAGS
+  -d, --include-disabled-rules  Includes disabled rules in fetched organization's ruleset
+  -h, --help                    Show CLI help.
+  -s, --include-system-rules    Includes system rules in fetched organization's ruleset
+
+DESCRIPTION
+  Get existing SwaggerHub's organization standardization ruleset.
+  Requires organization name argument. An error will occur if provided organization is non existing
+  or your account is not permitted to access that organization settings.
+  If the flag `-s` or `--include-system-rules` is used, the returned ruleset will also include SwaggerHub system rules.
+  If the flag `-d` or `--include-disabled-rules` is used, the returned ruleset will also include disabled custom rules
+
+EXAMPLES
+  $ swaggerhub api:validate:download-rules myOrg -s
+
+  $ swaggerhub api:validate:download-rules myOrg --include-disabled-rules -s
+```
+
+_See code: [src/commands/api/validate/download-rules.js](https://github.com/SmartBear/swaggerhub-cli/blob/v0.8.1/src/commands/api/validate/download-rules.js)_
 
 ## `swaggerhub configure`
 

--- a/README.md
+++ b/README.md
@@ -444,8 +444,8 @@ FLAGS
 
 DESCRIPTION
   Get existing SwaggerHub's organization standardization ruleset.
-  Requires organization name argument. An error will occur if provided organization is non existing
-  or your account is not permitted to access that organization settings.
+  Requires organization name argument. An error will occur if provided organization doesn't exist
+  or your account is not permitted to access that organization's settings.
   If the flag `-s` or `--include-system-rules` is used, the returned ruleset will also include SwaggerHub system rules.
   If the flag `-d` or `--include-disabled-rules` is used, the returned ruleset will also include disabled custom rules
 

--- a/src/commands/api/validate/download-rules.js
+++ b/src/commands/api/validate/download-rules.js
@@ -26,8 +26,8 @@ class ValidateDownloadRulesCommand extends BaseCommand {
 }
 
 ValidateDownloadRulesCommand.description = `Get existing SwaggerHub's organization standardization ruleset.
-Requires organization name argument. An error will occur if provided organization is non existing
-or your account is not permitted to access that organization settings.
+Requires organization name argument. An error will occur if provided organization doesn't exist
+or your account is not permitted to access that organization's settings.
 If the flag \`-s\` or \`--include-system-rules\` is used, the returned ruleset will also include SwaggerHub system rules.
 If the flag \`-d\` or \`--include-disabled-rules\` is used, the returned ruleset will also include disabled custom rules`
 

--- a/src/commands/api/validate/download-rules.js
+++ b/src/commands/api/validate/download-rules.js
@@ -6,13 +6,17 @@ const { getStandardization } = require('../../../requests/standardization')
 
 class ValidateDownloadRulesCommand extends BaseValidateCommand {
     async run() {
-        const { flags, args } = await this.parse(ValidateDownloadRulesCommand)
+        const { args, flags } = await this.parse(ValidateDownloadRulesCommand)
+
+        const includeSystemRules = flags['include-system-rules']
+        const includeDisabledRules = flags['include-disabled-rules']
         const organization = args['OWNER']
-        const standardizationConfig = await this.getOrganizationStandardizationConfig(organization, flags)
-        this.log(JSON.stringify(standardizationConfig, null, 2))
+
+        const organizationRuleset = await this.getExportedOrganizationRuleset(organization, {includeSystemRules, includeDisabledRules})
+        this.log(JSON.stringify(organizationRuleset, null, 2))
     }
 
-    getOrganizationStandardizationConfig(orgName, queryParams) {
+    getExportedOrganizationRuleset(orgName, queryParams) {
         return this.executeHttp({
             execute: () => getStandardization([orgName, 'spectral'], queryParams),
             onResolve: pipeAsync(getResponseContent, JSON.parse),
@@ -24,8 +28,8 @@ class ValidateDownloadRulesCommand extends BaseValidateCommand {
 ValidateDownloadRulesCommand.description = `TODO`
 
 ValidateDownloadRulesCommand.examples = [
-    'swaggerhub api:validate:download-rules myOrg -s=true',
-    'swaggerhub api:validate:download-rules myOrg --include-disabled-rules=true -s',
+    'swaggerhub api:validate:download-rules myOrg -s',
+    'swaggerhub api:validate:download-rules myOrg --include-disabled-rules -s',
 ]
 
 ValidateDownloadRulesCommand.args = {
@@ -35,12 +39,12 @@ ValidateDownloadRulesCommand.args = {
     })
 }
 ValidateDownloadRulesCommand.flags = {
-    includeSystemRules: Flags.boolean({
+    'include-system-rules': Flags.boolean({
         char: 's',
         description: 'Includes system rules in fetched organization\'s ruleset',
         required: false
     }),
-    includeDisabledRules: Flags.boolean({
+    'include-disabled-rules': Flags.boolean({
         char: 'd',
         description: 'Includes disabled rules in fetched organization\'s ruleset',
         required: false

--- a/src/commands/api/validate/download-rules.js
+++ b/src/commands/api/validate/download-rules.js
@@ -8,8 +8,8 @@ class ValidateDownloadRulesCommand extends BaseValidateCommand {
     async run() {
         const { args, flags } = await this.parse(ValidateDownloadRulesCommand)
 
-        const includeSystemRules = flags['include-system-rules']
-        const includeDisabledRules = flags['include-disabled-rules']
+        const includeSystemRules = flags['include-system-rules'] ?? false
+        const includeDisabledRules = flags['include-disabled-rules'] ?? false
         const organization = args['OWNER']
 
         const organizationRuleset = await this.getExportedOrganizationRuleset(organization, {includeSystemRules, includeDisabledRules})

--- a/src/commands/api/validate/download-rules.js
+++ b/src/commands/api/validate/download-rules.js
@@ -1,0 +1,50 @@
+const { Flags, Args } = require('@oclif/core')
+const BaseValidateCommand = require('../../../support/command/base-validate-command')
+const { pipeAsync } = require('../../../utils/general')
+const { getResponseContent } = require('../../../support/command/handle-response')
+const { getStandardization } = require('../../../requests/standardization')
+
+class ValidateDownloadRulesCommand extends BaseValidateCommand {
+    async run() {
+        const { flags, args } = await this.parse(ValidateDownloadRulesCommand)
+        const organization = args['OWNER']
+        const standardizationConfig = await this.getOrganizationStandardizationConfig(organization, flags)
+        this.log(JSON.stringify(standardizationConfig, null, 2))
+    }
+
+    getOrganizationStandardizationConfig(orgName, queryParams) {
+        return this.executeHttp({
+            execute: () => getStandardization([orgName, 'spectral'], queryParams),
+            onResolve: pipeAsync(getResponseContent, JSON.parse),
+            options: {}
+        })
+    }
+}
+
+ValidateDownloadRulesCommand.description = `TODO`
+
+ValidateDownloadRulesCommand.examples = [
+    'swaggerhub api:validate:download-rules myOrg -s=true',
+    'swaggerhub api:validate:download-rules myOrg --include-disabled-rules=true -s',
+]
+
+ValidateDownloadRulesCommand.args = {
+    'OWNER': Args.string({
+        required: true,
+        description: 'Which organization standardization rules to fetch from SwaggerHub'
+    })
+}
+ValidateDownloadRulesCommand.flags = {
+    includeSystemRules: Flags.boolean({
+        char: 's',
+        description: 'Includes system rules in fetched organization\'s ruleset',
+        required: false
+    }),
+    includeDisabledRules: Flags.boolean({
+        char: 'd',
+        description: 'Includes disabled rules in fetched organization\'s ruleset',
+        required: false
+    }),
+    ...BaseValidateCommand.flags
+}
+module.exports = ValidateDownloadRulesCommand

--- a/src/commands/api/validate/download-rules.js
+++ b/src/commands/api/validate/download-rules.js
@@ -1,10 +1,10 @@
 const { Flags, Args } = require('@oclif/core')
-const BaseValidateCommand = require('../../../support/command/base-validate-command')
+const BaseCommand = require('../../../support/command/base-command')
 const { pipeAsync } = require('../../../utils/general')
 const { getResponseContent } = require('../../../support/command/handle-response')
 const { getStandardization } = require('../../../requests/standardization')
 
-class ValidateDownloadRulesCommand extends BaseValidateCommand {
+class ValidateDownloadRulesCommand extends BaseCommand {
     async run() {
         const { args, flags } = await this.parse(ValidateDownloadRulesCommand)
 
@@ -25,7 +25,11 @@ class ValidateDownloadRulesCommand extends BaseValidateCommand {
     }
 }
 
-ValidateDownloadRulesCommand.description = `TODO`
+ValidateDownloadRulesCommand.description = `Get existing SwaggerHub's organization standardization ruleset.
+Requires organization name argument. An error will occur if provided organization is non existing
+or your account is not permitted to access that organization settings.
+If the flag \`-s\` or \`--include-system-rules\` is used, the returned ruleset will also include SwaggerHub system rules.
+If the flag \`-d\` or \`--include-disabled-rules\` is used, the returned ruleset will also include disabled custom rules`
 
 ValidateDownloadRulesCommand.examples = [
     'swaggerhub api:validate:download-rules myOrg -s',
@@ -49,6 +53,6 @@ ValidateDownloadRulesCommand.flags = {
         description: 'Includes disabled rules in fetched organization\'s ruleset',
         required: false
     }),
-    ...BaseValidateCommand.flags
+    ...BaseCommand.flags
 }
 module.exports = ValidateDownloadRulesCommand

--- a/src/requests/standardization.js
+++ b/src/requests/standardization.js
@@ -15,6 +15,18 @@ const postStandardization = (pathParams, body) => {
     })
 }
 
+const getStandardization = (pathParams, queryParams) => {
+    const { SWAGGERHUB_URL, SWAGGERHUB_API_KEY } = config.getConfig()
+
+    return http({
+        url: [SWAGGERHUB_URL, 'standardization', ...pathParams],
+        query: queryParams,
+        auth: SWAGGERHUB_API_KEY,
+        method: 'GET',
+    })
+}
+
 module.exports = {
-    postStandardization
+    postStandardization,
+    getStandardization
 }

--- a/src/requests/standardization.js
+++ b/src/requests/standardization.js
@@ -21,6 +21,7 @@ const getStandardization = (pathParams, queryParams) => {
     return http({
         url: [SWAGGERHUB_URL, 'standardization', ...pathParams],
         query: queryParams,
+        accept: 'json',
         auth: SWAGGERHUB_API_KEY,
         method: 'GET',
     })

--- a/test/commands/api/validate/download-rules.test.js
+++ b/test/commands/api/validate/download-rules.test.js
@@ -1,0 +1,96 @@
+const { expect, test } = require('@oclif/test')
+const config = require('../../../../src/config')
+const {
+    ruleset,
+    rulesetWithDisabledRule,
+    rulesetWithSystemRule,
+    rulesetWithDisabledAndSystemRule, basicRules
+} = require('../../../resources/rulesets')
+
+const orgName = 'org1'
+describe('invalid api:validate:download-rules', () => {
+    test
+        .stdout()
+        .command(['api:validate:download-rules'])
+        .exit(2)
+        .it('runs api:validate:download-rules with no organization name provided')
+
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/org2/spectral`)
+            .query({ includeSystemRules : false, includeDisabledRules : false})
+            .reply(404, 'Access Denied')
+        )
+        .command(['api:validate:download-rules', 'org2'])
+        .exit(2)
+        .it('Access Denied returned when trying to fetch ruleset of not existing organization')
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/org2/spectral`)
+            .query({ includeSystemRules : false, includeDisabledRules : false})
+            .reply(404, 'Access Denied')
+        )
+        .command(['api:validate:download-rules', 'org2'])
+        .exit(2)
+        .it('Access Denied returned when trying to fetch ruleset of not existing organization')
+})
+
+describe('valid api:validate:download-rules', () => {
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/${orgName}/spectral`)
+            .query({ includeSystemRules : false, includeDisabledRules : false})
+            .reply(200, ruleset)
+        )
+        .stdout()
+        .command(['api:validate:download-rules', 'org1'])
+        .it('runs api:validate:download-rules and returns organization rules without system rules nor disabled rules', ctx => {
+            expect(ctx.stdout).to.contains(JSON.stringify(ruleset, null, 2))
+        })
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/${orgName}/spectral`)
+            .query({ includeSystemRules : true, includeDisabledRules : false})
+            .reply(200, rulesetWithSystemRule)
+        )
+        .stdout()
+        .command(['api:validate:download-rules', 'org1', '-s'])
+        .it('runs api:validate:download-rules and returns organization rules with system rules, but without disabled rules', ctx => {
+            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithSystemRule, null, 2))
+        })
+
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/${orgName}/spectral`)
+            .query({ includeSystemRules : false, includeDisabledRules : true})
+            .reply(200, rulesetWithDisabledRule)
+        )
+        .stdout()
+        .command(['api:validate:download-rules', 'org1', '-d'])
+        .it('runs api:validate:download-rules and returns organization rules without system rules, but with disabled rules', ctx => {
+            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithDisabledRule, null, 2))
+        })
+
+
+    test
+        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
+        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
+            .get(`/${orgName}/spectral`)
+            .query({ includeSystemRules : true, includeDisabledRules : true})
+            .reply(200, rulesetWithDisabledAndSystemRule)
+        )
+        .stdout()
+        .command(['api:validate:download-rules', 'org1', '-s', '-d'])
+        .it('runs api:validate:download-rules and returns organization rules with system rules and disabled rules', ctx => {
+            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithDisabledAndSystemRule, null, 2))
+        })
+})

--- a/test/commands/api/validate/download-rules.test.js
+++ b/test/commands/api/validate/download-rules.test.js
@@ -4,7 +4,7 @@ const {
     ruleset,
     rulesetWithDisabledRule,
     rulesetWithSystemRule,
-    rulesetWithDisabledAndSystemRule, basicRules
+    rulesetWithDisabledAndSystemRule
 } = require('../../../resources/rulesets')
 
 const orgName = 'org1'
@@ -15,7 +15,6 @@ describe('invalid api:validate:download-rules', () => {
         .exit(2)
         .it('runs api:validate:download-rules with no organization name provided')
 
-
     test
         .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
         .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
@@ -25,18 +24,15 @@ describe('invalid api:validate:download-rules', () => {
         )
         .command(['api:validate:download-rules', 'org2'])
         .exit(2)
-        .it('Access Denied returned when trying to fetch ruleset of not existing organization')
+        .it('Access Denied returned when trying to fetch ruleset of not existing or not available organization')
 
     test
-        .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
-        .nock('https://api.swaggerhub.com/standardization',{ reqheaders: { Accept: 'application/json' }}, api => api
-            .get(`/org2/spectral`)
-            .query({ includeSystemRules : false, includeDisabledRules : false})
-            .reply(404, 'Access Denied')
+        .stub(config, 'isURLValid', () => false)
+        .command(['api:validate:download-rules', 'org1'])
+        .catch(ctx =>
+            expect(ctx.message).to.equal('Please verify that the configured SwaggerHub URL is correct.')
         )
-        .command(['api:validate:download-rules', 'org2'])
-        .exit(2)
-        .it('Access Denied returned when trying to fetch ruleset of not existing organization')
+        .it('invalid SwaggerHub URL provided in the config')
 })
 
 describe('valid api:validate:download-rules', () => {
@@ -65,7 +61,6 @@ describe('valid api:validate:download-rules', () => {
         .it('runs api:validate:download-rules and returns organization rules with system rules, but without disabled rules', ctx => {
             expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithSystemRule, null, 2))
         })
-
 
     test
         .stub(config, 'getConfig', () => ({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))

--- a/test/resources/rulesets.js
+++ b/test/resources/rulesets.js
@@ -1,0 +1,68 @@
+const baseRulesetConfiguration = {
+    "extends": [
+        "https://api.dev.swaggerhub.com/standardization/spectral/system-rules",
+        "https://api.dev.swaggerhub.com/standardization/spectral/styleguide/owasp-top-10.js"
+    ],
+    "documentationUrl": "https://support.smartbear.com/swaggerhub/docs/en/manage-resource-access/api-standardization.html#UUID-5425b1a0-27d3-677c-54f2-f2acab09a7a6_section-idm4667026578035233960922912739",
+}
+
+const basicRules = {
+    "owasp:api1:2019-no-numeric-ids": "error",
+    "custom-rule": {
+        "description": "description",
+        "message": "message",
+        "formats": [
+            "oas2",
+            "oas3_0",
+            "oas3_1"
+        ],
+        "severity": "off",
+        "given": "$.info.title",
+        "then": {
+            "function": "pattern",
+            "functionOptions": {
+                "match": "some-title"
+            }
+        }
+    }
+}
+
+const disabledRule ={
+    "disabled-custom-rule": {
+        "description": "description",
+        "message": "message",
+        "formats": [
+            "oas2",
+            "oas3_0",
+            "oas3_1"
+        ],
+        "severity": "off",
+        "given": "$.info.title",
+        "then": {
+            "function": "pattern",
+            "functionOptions": {
+                "match": "some-title"
+            }
+        }
+    }
+}
+
+const systemRule ={
+    "swaggerhub-asyncapi-tags-at-least-one": "error"
+}
+
+const ruleset = {...baseRulesetConfiguration, rules: basicRules}
+const rulesetWithSystemRule = {...baseRulesetConfiguration, rules: {...basicRules, ...systemRule}}
+const rulesetWithDisabledRule = {...baseRulesetConfiguration, rules: {...basicRules, ...disabledRule}}
+const rulesetWithDisabledAndSystemRule = {...baseRulesetConfiguration, rules: {...basicRules, ...disabledRule, ...systemRule}}
+
+module.exports = {
+    ruleset,
+    rulesetWithSystemRule,
+    rulesetWithDisabledRule,
+    rulesetWithDisabledAndSystemRule
+}
+
+
+
+

--- a/test/resources/rulesets.js
+++ b/test/resources/rulesets.js
@@ -62,7 +62,3 @@ module.exports = {
     rulesetWithDisabledRule,
     rulesetWithDisabledAndSystemRule
 }
-
-
-
-


### PR DESCRIPTION
This PR adds command that allows users to fetch their organization's standardization ruleset using Swaggerhub-CLI (Export functionality)

* [X] I have added the appropriate label to my PR