### PR TITLE
ci: added ci build and tests using node 22

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to support a newer version of Node.js and use the latest versions of certain actions.

Updates to GitHub Actions workflows:

* [`.github/workflows/build-main.yaml`](diffhunk://#diff-ed9008ce7f1c6c1ded18f4804e75aeb30f94697dc2eef5a1e5e2f5b1e73fd278L12-R16): Added Node.js version 22.x to the matrix and updated `actions/checkout` to v4 and `actions/setup-node` to v4.
* [`.github/workflows/pull-request.yaml`](diffhunk://#diff-a8619735ff14304aa0514284f86ff5145b0a6bae2e76a37faeb0ad899a3d8db4L10-R14): Added Node.js version 22.x to the matrix and updated `actions/checkout` to v4 and `actions/setup-node` to v4.

* [x] I have added the appropriate label to my PR (none is matching)