### PR TITLE
the release job updates versions, creates readme and release PR

### DIFF
--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -1,0 +1,96 @@
+name: Deployment
+
+run-name: 'Release from ${{ github.ref_name }}'
+
+on:
+  pull_request:
+    branches:
+      - test
+    types:
+      - closed
+
+jobs:
+  version-and-tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract version from source branch name
+        id: extract_version
+        run: |
+          VERSION=${GITHUB_HEAD_REF#release/}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Source branch version: $VERSION"
+      # tag the commit with the version and push the tag
+      - name: Tag the commit with the version
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag -a $VERSION -m "Release version $VERSION"
+      - name: Push the tag to the repository
+        run: |
+          echo "Pushing tag $VERSION"
+          git push origin "$VERSION" --follow-tags
+
+  publish-github:
+    runs-on: ubuntu-latest
+    needs: [ version-and-tag ]
+
+    permissions:
+      contents: write
+
+    env:
+      VERSION: ${{ needs.version-and-tag.outputs.VERSION }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - run: echo "Creating GitHub release for version ${{ env.VERSION }}"
+      - name: Create GitHub Release
+        uses: octokit/request-action@v2.x
+        id: create_release
+        with:
+          route: POST /repos/{owner}/{repo}/releases
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    needs: [version-and-tag, publish-github]
+    env:
+      VERSION: ${{ needs.version-and-tag.outputs.VERSION }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ env.VERSION }}
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Publish swaggerhub-cli ${{ env.VERSION }} to npm
+        run: |
+          echo "Publishing version $VERSION to npm"
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-on-github.yaml
+++ b/.github/workflows/release-on-github.yaml
@@ -42,11 +42,11 @@ jobs:
           npx oclif readme && node src/format-readme.js
           git checkout -b release/${VERSION}
           echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Release version ${VERSION} PR created" >> $GITHUB_STEP_SUMMARY
 
       - name: Create release PR
         run: |
           git commit \
-           -am "Release of ${VERSION}" \
-           -m "[skip ci]"
-          git push origin --follow-tags
+           -am "Release of ${VERSION}"
+          git push --set-upstream origin
+          gh pr create --base main --head release/${VERSION} --title "Release v${VERSION}" --body "Release of CLI version ${VERSION}"
+          echo "Release version ${VERSION} PR created" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-on-github.yaml
+++ b/.github/workflows/release-on-github.yaml
@@ -33,64 +33,20 @@ jobs:
       - run: npm ci
 
       - name: Bump version and regenerate README
+        id: create_tags
         run: |
           # https://github.com/orgs/community/discussions/26560
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           VERSION=$(npm version ${{inputs.type}} --no-git-tag-version)
           npx oclif readme && node src/format-readme.js
-          git commit -am "Release for ${VERSION}"
-          git tag $VERSION
+          git checkout -b release/${VERSION}
           echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Released version ${VERSION}" >> $GITHUB_STEP_SUMMARY
-        id: create_tags
+          echo "Release version ${VERSION} PR created" >> $GITHUB_STEP_SUMMARY
 
-      - run: git push origin --follow-tags
-  
-  publish-github:
-    runs-on: ubuntu-latest
-
-    needs: bump-version
-    permissions:
-      contents: write
-    env:
-      VERSION: ${{ needs.bump-version.outputs.RELEASE_VERSION }}
-
-    steps:
-      - name: Create GitHub Release
-        uses: octokit/request-action@v2.x
-        id: create_release
-        with:
-          route: POST /repos/{owner}/{repo}/releases
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          tag_name: ${{ env.VERSION }}
-          name: ${{ env.VERSION }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-npm:
-    runs-on: ubuntu-latest
-
-    needs: [bump-version, publish-github]
-    env:
-      VERSION: ${{ needs.bump-version.outputs.RELEASE_VERSION }}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ env.VERSION }}
-
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      
-      - run: npm ci
-
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create release PR
+        run: |
+          git commit \
+           -am "Release of ${VERSION}" \
+           -m "[skip ci]"
+          git push origin --follow-tags


### PR DESCRIPTION
This pull request introduces a new workflow for deployment and modifies the existing release workflow to streamline the process of creating release branches and publishing releases. The most important changes include the addition of a deployment workflow, extraction of version information, tagging commits, and publishing to GitHub and npm.

### New Deployment Workflow:

* [`.github/workflows/deploy-release.yaml`](diffhunk://#diff-d8afbe8d1fc0b9fe347759a07853b35b70b0f3e4b1a22ded2ad0a5e1f6b28b76R1-R96): Added a new deployment workflow triggered by closed pull requests on the `test` branch. This workflow extracts the version from the source branch, tags the commit, and publishes the release to GitHub and npm.

### Modifications to Release Workflow:

* [`.github/workflows/release-on-github.yaml`](diffhunk://#diff-fc00ce6c11e271e0c8f700afbad93ef38e063a600c0449a884209770c2365c27R36-R52): Modified the release workflow to create a release branch instead of directly tagging the commit, and updated the steps to create a release pull request.