### PR TITLE
ci: new ubuntu will soon be the -latest, freezing the version on 24.04

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [ 18.x, 20.x, 22.x ]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   version-and-tag:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
@@ -40,7 +40,7 @@ jobs:
           git push origin "$VERSION" --follow-tags
 
   publish-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ version-and-tag ]
 
     permissions:
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     needs: [version-and-tag, publish-github]
     env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [ 18.x, 20.x, 22.x ]

--- a/.github/workflows/release-on-github.yaml
+++ b/.github/workflows/release-on-github.yaml
@@ -16,7 +16,7 @@ on:
         default: minor
 jobs:
   bump-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       RELEASE_VERSION: ${{ steps.create_tags.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
This PR freezes the version of OS that jobs are using so that change in -latest of Ubuntu does not influence the build and release process

* [x] I have added the appropriate label to my PR