### PR TITLE
chore(tests): refactor assertions to use 'to.contain' instead of 'to.contains'

### DIFF
--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -141,7 +141,7 @@ describe('invalid api:create', () => {
       '--setdefault'
     ])
     .catch(err => {
-      expect(err.message).to.contains('Object doesn\'t exist')
+      expect(err.message).to.contain('Object doesn\'t exist')
     })
     .it('error shows as create failed and publish and setdefault are not executed')
   
@@ -162,7 +162,7 @@ describe('invalid api:create', () => {
     )
     .command(['api:create', validIdentifier, '-f=test/resources/valid_api.yaml', '--setdefault', '--published=publish'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Publishing API failed')
+      expect(err.message).to.contain('An error occurred. Publishing API failed')
     })
     .it('error shows as publish failed and setdefault is not executed')
 
@@ -187,7 +187,7 @@ describe('invalid api:create', () => {
     )
     .command(['api:create', validIdentifier, '-f=test/resources/valid_api.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Setting default version failed')
+      expect(err.message).to.contain('An error occurred. Setting default version failed')
     })
     .it('error shows as setdefault failed')
 })
@@ -207,7 +207,7 @@ describe('valid api:create', () => {
     .stdout()
     .command(['api:create', validIdentifier, '--file=test/resources/valid_api.yaml'])
     .it('runs api:create with yaml file', ctx => {
-      expect(ctx.stdout).to.contains('Created API \'org/api\'')
+      expect(ctx.stdout).to.contain('Created API \'org/api\'')
     })
 
   test
@@ -228,7 +228,7 @@ describe('valid api:create', () => {
     .stdout()
     .command(['api:create', validIdentifier, '--file=test/resources/valid_api.yaml', '--setdefault'])
     .it('runs api:create to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Created API \'org/api\'\nDefault version of org/api set to 1.0.0')
+      expect(ctx.stdout).to.contain('Created API \'org/api\'\nDefault version of org/api set to 1.0.0')
     })
 
   test
@@ -249,7 +249,7 @@ describe('valid api:create', () => {
     .stdout()
     .command(['api:create', validIdentifier, '--file=test/resources/valid_api.yaml', '--published=publish'])
     .it('runs api:create to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Created API \'org/api\'\nPublished API org/api/1.0.0')
+      expect(ctx.stdout).to.contain('Created API \'org/api\'\nPublished API org/api/1.0.0')
     })
 
   test
@@ -331,7 +331,7 @@ describe('valid api:create', () => {
       '--visibility=public'
     ])
     .it('runs api:create with json file', ctx => {
-      expect(ctx.stdout).to.contains('Created API \'org/api\'')
+      expect(ctx.stdout).to.contain('Created API \'org/api\'')
     })
 
   test
@@ -353,7 +353,7 @@ describe('valid api:create', () => {
         '--visibility=public'
       ])
       .it('runs api:create with asyncapi json file', ctx => {
-        expect(ctx.stdout).to.contains('Created API \'org/api\'')
+        expect(ctx.stdout).to.contain('Created API \'org/api\'')
       })
   test
       .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
@@ -374,7 +374,7 @@ describe('valid api:create', () => {
         '--visibility=public'
       ])
       .it('runs api:create with asyncapi yaml file', ctx => {
-        expect(ctx.stdout).to.contains('Created API \'org/api\'')
+        expect(ctx.stdout).to.contain('Created API \'org/api\'')
       })
 })
 
@@ -397,7 +397,7 @@ describe('valid create new version with api:create', () => {
     .stdout()
     .command(['api:create', 'org/api', '--file=test/resources/valid_api.yaml'])
     .it('runs api:create with yaml file reading version from file', ctx => {
-      expect(ctx.stdout).to.contains('Created version 1.0.1 of API \'org/api\'')
+      expect(ctx.stdout).to.contain('Created version 1.0.1 of API \'org/api\'')
     })
 
   test
@@ -422,7 +422,7 @@ describe('valid create new version with api:create', () => {
       '--visibility=public'
     ])
     .it('runs api:create with json file reading version from file', ctx => {
-      expect(ctx.stdout).to.contains('Created version 2.0.0 of API \'org/api\'')
+      expect(ctx.stdout).to.contain('Created version 2.0.0 of API \'org/api\'')
     })
 })
 

--- a/test/commands/api/delete.test.js
+++ b/test/commands/api/delete.test.js
@@ -15,7 +15,7 @@ describe('valid api:delete', () => {
     .stdout()
     .command(['api:delete', apiVersionId])
     .it('runs api:delete on API version', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted version 1.0.0 of API '${apiId}'`)
+      expect(ctx.stdout).to.contain(`Deleted version 1.0.0 of API '${apiId}'`)
     })
 
   test
@@ -28,7 +28,7 @@ describe('valid api:delete', () => {
     .stdout()
     .command(['api:delete', apiId])
     .it('runs api:delete on API defintion', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted API '${apiId}'`)
+      expect(ctx.stdout).to.contain(`Deleted API '${apiId}'`)
     })
 
   test
@@ -47,7 +47,7 @@ describe('valid api:delete', () => {
     .stdout()
     .command(['api:delete', apiId, '-f'])
     .it('runs api:delete on API defintion with -f flag', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted API '${apiId}'`)
+      expect(ctx.stdout).to.contain(`Deleted API '${apiId}'`)
     })
 
   test
@@ -59,7 +59,7 @@ describe('valid api:delete', () => {
     .stdout()
     .command(['api:delete', apiId, '--force'])
     .it('runs api:delete on API defintion with --force flag', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted API '${apiId}'`)
+      expect(ctx.stdout).to.contain(`Deleted API '${apiId}'`)
     })
 })
 

--- a/test/commands/api/get.test.js
+++ b/test/commands/api/get.test.js
@@ -35,7 +35,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2/1.0.0', '--json'])
     .it('runs api:get --json and returns response in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+      expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
     })
 
   test
@@ -47,7 +47,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2/1.0.0', '-j'])
     .it('runs api:get -j and returns response in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+      expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
     })
 
   test
@@ -59,7 +59,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2/1.0.0'])
     .it('runs api:get and returns response in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+      expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
     })
 
   test
@@ -75,7 +75,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2'])
     .it('runs api:get to return default API version in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+      expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
     })
 
   test
@@ -91,7 +91,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2', '-j'])
     .it('runs api:get to return default API version in json format', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+      expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
     })
 
   test
@@ -103,7 +103,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2/1.0.0', '--resolved'])
     .it('runs api:get --resolved to return resolved API definition in yaml format', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+      expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
     })
 
   test
@@ -119,7 +119,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2', '-r'])
     .it('run api:get -r and returns resolved default API version', ctx => {
-      expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+      expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
     })
 
   test
@@ -131,7 +131,7 @@ describe('valid identifier on api:get', () => {
     .stdout()
     .command(['api:get', 'org1/api2/1.0.0', '-jr'])
     .it('runs api:get -jr to return resolved definition', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+      expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
     })
 })
 

--- a/test/commands/api/publish.test.js
+++ b/test/commands/api/publish.test.js
@@ -14,7 +14,7 @@ describe('valid api:publish', () => {
   .stdout()
   .command(['api:publish', 'org/api/1.0.0'])
   .it('runs api:publish with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Published API org/api/1.0.0')
+    expect(ctx.stdout).to.contain('Published API org/api/1.0.0')
   })
 
   test
@@ -41,7 +41,7 @@ describe('valid api:publish', () => {
   .stdout()
   .command(['api:publish', 'org/api/1.0.0', '--force'])
   .it('runs api:publish with force argument', ctx => {
-    expect(ctx.stdout).to.contains('Published API org/api/1.0.0')
+    expect(ctx.stdout).to.contain('Published API org/api/1.0.0')
   })
 })
 

--- a/test/commands/api/setdefault.test.js
+++ b/test/commands/api/setdefault.test.js
@@ -12,7 +12,7 @@ describe('valid api:setdefault', () => {
   .stdout()
   .command(['api:setdefault', 'org/api/2.0.0'])
   .it('runs api:setdefault with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+    expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
   })
 })
 

--- a/test/commands/api/unpublish.test.js
+++ b/test/commands/api/unpublish.test.js
@@ -12,7 +12,7 @@ describe('valid api:unpublish', () => {
   .stdout()
   .command(['api:unpublish', 'org/api/1.0.0'])
   .it('runs api:unpublish with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Unpublished API org/api/1.0.0')
+    expect(ctx.stdout).to.contain('Unpublished API org/api/1.0.0')
   })
 })
 

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -12,7 +12,7 @@ describe('invalid api:update command issues', () => {
   test
     .command(['api:update', 'invalid'])
     .catch(err => {
-      expect(err.message).to.contains('No updates specified')
+      expect(err.message).to.contain('No updates specified')
     })
     .it('runs api:update with no required --file flag')
 
@@ -111,7 +111,7 @@ describe('invalid api:update', () => {
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('Unknown API org/api/1.0.0')
+      expect(err.message).to.contain('Unknown API org/api/1.0.0')
     })
     .it('error shows as update failed and publish and setdefault are not executed')
 
@@ -131,7 +131,7 @@ describe('invalid api:update', () => {
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--setdefault', '--published=publish'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Publishing API failed')
+      expect(err.message).to.contain('An error occurred. Publishing API failed')
     })
     .it('error shows as publish failed and setdefault is not executed')
 
@@ -155,7 +155,7 @@ describe('invalid api:update', () => {
     )
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Setting default version failed')
+      expect(err.message).to.contain('An error occurred. Setting default version failed')
     })
     .it('error shows as setdefault failed')
 
@@ -166,7 +166,7 @@ describe('invalid api:update', () => {
     .command(['api:update', 'org/api/2.0.0'])
 
     .catch(err => {
-      expect(err.message).to.contains('No updates specified')
+      expect(err.message).to.contain('No updates specified')
     })
     .it('error shows as no flag is provided')
 })
@@ -186,7 +186,7 @@ describe('valid api:update', () => {
     .command(['api:update', `${validIdentifier}`, '-f=test/resources/valid_api.yaml'])
 
     .it('runs api:update with YAML file', ctx => {
-      expect(ctx.stdout).to.contains(`Updated API ${validIdentifier}`)
+      expect(ctx.stdout).to.contain(`Updated API ${validIdentifier}`)
     })
 
   test
@@ -203,7 +203,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json'])
 
     .it('runs api:update with JSON file, version read from file', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
     })
 
   test
@@ -220,7 +220,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility=public'])
 
     .it('runs api:update to set API public', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
     })
 
   test
@@ -237,7 +237,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--visibility=private'])
 
     .it('runs api:update to set API private', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
     })
 
   test
@@ -255,7 +255,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '--visibility=public'])
 
     .it('runs api:update to set API public without a version arg', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Updated visibility of org/api/2.0.0 to public')
     })
 
   test
@@ -273,7 +273,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--visibility=private'])
 
     .it('runs api:update to set API private', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to private')
+      expect(ctx.stdout).to.contain('Updated visibility of org/api/2.0.0 to private')
     })
 
   test
@@ -294,8 +294,8 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--published=publish'])
 
     .it('runs api:update to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Published API org/api/2.0.0')
     })
 
   test
@@ -316,8 +316,8 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--published=unpublish'])
 
     .it('runs api:update to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Unpublished API org/api/2.0.0')
     })
 
   test
@@ -338,8 +338,8 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault'])
 
     .it('runs api:update to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 
   test
@@ -364,9 +364,9 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--published=publish', '--setdefault'])
 
     .it('runs api:update to set API public, publish API, and set the default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
-      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated visibility of org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 
   test
@@ -391,9 +391,9 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--visibility=public', '--published=unpublish', '--setdefault'])
 
     .it('runs api:update to set API public, publish API, and set the default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/api/2.0.0 to public')
-      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated visibility of org/api/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Unpublished API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 
   test
@@ -425,9 +425,9 @@ describe('valid api:update', () => {
     ])
 
     .it('runs api:update to set API public, publish API, and set the default version with file flag', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0 and visibility is set to public')
-      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0 and visibility is set to public')
+      expect(ctx.stdout).to.contain('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 
   test
@@ -452,9 +452,9 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api', '-f=test/resources/valid_api.json', '--setdefault', '--published=publish'])
 
     .it('runs api:update to publish API and set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 
   test
@@ -471,7 +471,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--published=publish'])
 
     .it('runs api:update to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Published API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Published API org/api/2.0.0')
     })
 
   test
@@ -488,7 +488,7 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--published=unpublish'])
 
     .it('runs api:update to publish API', ctx => {
-      expect(ctx.stdout).to.contains('Unpublished API org/api/2.0.0')
+      expect(ctx.stdout).to.contain('Unpublished API org/api/2.0.0')
     })
 
   test
@@ -505,6 +505,6 @@ describe('valid api:update', () => {
     .command(['api:update', 'org/api/2.0.0', '--setdefault'])
 
     .it('runs api:update to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Default version of org/api set to 2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/api set to 2.0.0')
     })
 })

--- a/test/commands/api/validate/download-rules.test.js
+++ b/test/commands/api/validate/download-rules.test.js
@@ -47,7 +47,7 @@ describe('valid api:validate:download-rules', () => {
         .stdout()
         .command(['api:validate:download-rules', 'org1'])
         .it('runs api:validate:download-rules and returns organization rules without system rules nor disabled rules', ctx => {
-            expect(ctx.stdout).to.contains(JSON.stringify(ruleset, null, 2))
+            expect(ctx.stdout).to.contain(JSON.stringify(ruleset, null, 2))
         })
 
     test
@@ -60,7 +60,7 @@ describe('valid api:validate:download-rules', () => {
         .stdout()
         .command(['api:validate:download-rules', 'org1', '-s'])
         .it('runs api:validate:download-rules and returns organization rules with system rules, but without disabled rules', ctx => {
-            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithSystemRule, null, 2))
+            expect(ctx.stdout).to.contain(JSON.stringify(rulesetWithSystemRule, null, 2))
         })
 
     test
@@ -73,7 +73,7 @@ describe('valid api:validate:download-rules', () => {
         .stdout()
         .command(['api:validate:download-rules', 'org1', '-d'])
         .it('runs api:validate:download-rules and returns organization rules without system rules, but with disabled rules', ctx => {
-            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithDisabledRule, null, 2))
+            expect(ctx.stdout).to.contain(JSON.stringify(rulesetWithDisabledRule, null, 2))
         })
 
 
@@ -87,6 +87,6 @@ describe('valid api:validate:download-rules', () => {
         .stdout()
         .command(['api:validate:download-rules', 'org1', '-s', '-d'])
         .it('runs api:validate:download-rules and returns organization rules with system rules and disabled rules', ctx => {
-            expect(ctx.stdout).to.contains(JSON.stringify(rulesetWithDisabledAndSystemRule, null, 2))
+            expect(ctx.stdout).to.contain(JSON.stringify(rulesetWithDisabledAndSystemRule, null, 2))
         })
 })

--- a/test/commands/api/validate/index.test.js
+++ b/test/commands/api/validate/index.test.js
@@ -118,7 +118,7 @@ describe('valid api:validate for swaggerhub on-premise <= 2.4.1', () => {
   .command(['api:validate', apiPath])
   .exit(0)
   .it('should fall back to legacy /validation endpoint and return errors', ctx => {
-    expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+    expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
   })
 })
 
@@ -149,7 +149,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
 
@@ -173,7 +173,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
     
@@ -197,7 +197,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
   })
@@ -225,7 +225,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -250,7 +250,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '-c', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -274,7 +274,7 @@ describe('valid api:validate', () => {
       .command(['api:validate', '--fail-on-critical', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
   })
@@ -297,7 +297,7 @@ describe('valid api:validate', () => {
     .command(['api:validate', apiPath])
     .exit(0)
     .it('should return empty result as there is no error', ctx => {
-      expect(ctx.stdout).to.contains('')
+      expect(ctx.stdout).to.contain('')
     })
 
     test.stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: 'https://api.swaggerhub.com' }))
@@ -321,7 +321,7 @@ describe('valid api:validate', () => {
     .command(['api:validate', apiPath.substring(0, apiPath.lastIndexOf('/'))])
     .exit(0)
     .it('should resolve version and return empty result as there is no error', ctx => {
-      expect(ctx.stdout).to.contains('')
+      expect(ctx.stdout).to.contain('')
     })
   })
 })

--- a/test/commands/api/validate/local.test.js
+++ b/test/commands/api/validate/local.test.js
@@ -77,7 +77,7 @@ describe('valid api:validate:local', () => {
       ])
       .exit(0)
       .it('should return validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
 
@@ -97,7 +97,7 @@ describe('valid api:validate:local', () => {
       ]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
 
@@ -117,7 +117,7 @@ describe('valid api:validate:local', () => {
       ]) // swaggerhub api:validate o/a/v
       .exit(1)
       .it('should return validation errors, one per line, with exit code 1', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity} ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity} ${description}`)
       })
     })
   })
@@ -139,7 +139,7 @@ describe('valid api:validate:local', () => {
       .command(['api:validate:local', '-o', orgName, '-f', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -157,7 +157,7 @@ describe('valid api:validate:local', () => {
       .command(['api:validate:local', '-c', '-o', orgName, '-f', apiPath]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
 
@@ -177,7 +177,7 @@ describe('valid api:validate:local', () => {
       ]) // swaggerhub api:validate o/a/v
       .exit(0)
       .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-        expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+        expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
       })
     })
   })
@@ -214,7 +214,7 @@ describe('valid api:validate:local', () => {
     .command(['api:validate:local', '-o', orgName, '-f', jsonApiPath])
     .exit(0)
     .it('should return warning validation errors, one per line, with exit code 0', ctx => {
-      expect(ctx.stdout).to.contains(`${heading} ${line}   ${severity}  ${description}`)
+      expect(ctx.stdout).to.contain(`${heading} ${line}   ${severity}  ${description}`)
     })
   })
 })

--- a/test/commands/configure.test.js
+++ b/test/commands/configure.test.js
@@ -22,7 +22,7 @@ describe('configure command', () => {
       .command(['configure'])
       .it('runs sets up config and logs the location of the file', ctx => {
         const configFilePath = [...ctx.config.configDir.split(path.sep), 'config.json'].join(path.sep)
-        expect(ctx.stdout).to.contains(`Saved config to ${configFilePath}`)
+        expect(ctx.stdout).to.contain(`Saved config to ${configFilePath}`)
       })
   })
   

--- a/test/commands/domain/create.test.js
+++ b/test/commands/domain/create.test.js
@@ -129,7 +129,7 @@ describe('invalid domain:create', () => {
     .command(['domain:create', 'orgNotExist/domain/1.0.0', '-f=test/resources/valid_domain.yaml',
       '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('Object doesn\'t exist')
+      expect(err.message).to.contain('Object doesn\'t exist')
     })
     .it('error shows as create failed and publish and setdefault are not executed')
 
@@ -150,7 +150,7 @@ describe('invalid domain:create', () => {
     )
     .command(['domain:create', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--setdefault', '--published=publish'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Publishing domain failed')
+      expect(err.message).to.contain('An error occurred. Publishing domain failed')
     })
     .it('error shows as publish failed and setdefault is not executed')
 
@@ -175,7 +175,7 @@ describe('invalid domain:create', () => {
     )
     .command(['domain:create', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Setting default version failed')
+      expect(err.message).to.contain('An error occurred. Setting default version failed')
     })
     .it('error shows as setdefault failed')
 })
@@ -195,7 +195,7 @@ describe('valid domain:create', () => {
     .stdout()
     .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.yaml'])
     .it('runs domain:create with yaml file', ctx => {
-      expect(ctx.stdout).to.contains('Created domain \'org/domain\'')
+      expect(ctx.stdout).to.contain('Created domain \'org/domain\'')
     })
 
   test
@@ -216,7 +216,7 @@ describe('valid domain:create', () => {
     .stdout()
     .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.yaml', '--setdefault'])
     .it('runs domain:create to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Created domain \'org/domain\'\nDefault version of org/domain set to 1.0.0')
+      expect(ctx.stdout).to.contain('Created domain \'org/domain\'\nDefault version of org/domain set to 1.0.0')
     })
 
   test
@@ -237,7 +237,7 @@ describe('valid domain:create', () => {
     .stdout()
     .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.yaml', '--published=publish'])
     .it('runs domain:create to publish domain', ctx => {
-      expect(ctx.stdout).to.contains('Created domain \'org/domain\'\nPublished domain org/domain/1.0.0')
+      expect(ctx.stdout).to.contain('Created domain \'org/domain\'\nPublished domain org/domain/1.0.0')
     })
 
   test
@@ -254,7 +254,7 @@ describe('valid domain:create', () => {
     .stdout()
     .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.yaml', '--published=unpublish'])
     .it('runs domain:create with published=unpublish', ctx => {
-      expect(ctx.stdout).to.contains('Created domain \'org/domain\'')
+      expect(ctx.stdout).to.contain('Created domain \'org/domain\'')
     })
 
   test
@@ -304,7 +304,7 @@ describe('valid domain:create', () => {
       '--visibility=public'
     ])
     .it('runs domain:create with json file', ctx => {
-      expect(ctx.stdout).to.contains('Created domain \'org/domain\'')
+      expect(ctx.stdout).to.contain('Created domain \'org/domain\'')
     })
 })
 
@@ -327,7 +327,7 @@ describe('valid create new version with domain:create', () => {
     .stdout()
     .command(['domain:create', 'org/domain', '--file=test/resources/valid_domain.yaml'])
     .it('runs domain:create with yaml file reading version from file', ctx => {
-      expect(ctx.stdout).to.contains('Created version 1.2.3 of domain \'org/domain\'')
+      expect(ctx.stdout).to.contain('Created version 1.2.3 of domain \'org/domain\'')
     })
 
   test
@@ -352,7 +352,7 @@ describe('valid create new version with domain:create', () => {
       '--visibility=public'
     ])
     .it('runs domain:create with json file reading version from file', ctx => {
-      expect(ctx.stdout).to.contains('Created version 1.2.3 of domain \'org/domain\'')
+      expect(ctx.stdout).to.contain('Created version 1.2.3 of domain \'org/domain\'')
     })
 })
 

--- a/test/commands/domain/delete.test.js
+++ b/test/commands/domain/delete.test.js
@@ -17,7 +17,7 @@ describe('valid domain:delete', () => {
     .stdout()
     .command(['domain:delete', versionId])
     .it('runs domain:delete on domain version', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted version 1.0.0 of domain '${domainId}'`)
+      expect(ctx.stdout).to.contain(`Deleted version 1.0.0 of domain '${domainId}'`)
     })
 
   test
@@ -30,7 +30,7 @@ describe('valid domain:delete', () => {
     .stdout()
     .command(['domain:delete', domainId, '-f'])
     .it('runs domain:delete on domain defintion with -f flag', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted domain '${domainId}'`)
+      expect(ctx.stdout).to.contain(`Deleted domain '${domainId}'`)
     })
 
   test
@@ -43,7 +43,7 @@ describe('valid domain:delete', () => {
     .stdout()
     .command(['domain:delete', domainId, '--force'])
     .it('runs domain:delete on domain defintion with --force flag', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted domain '${domainId}'`)
+      expect(ctx.stdout).to.contain(`Deleted domain '${domainId}'`)
     })
 })
 
@@ -98,7 +98,7 @@ describe('inquirer prompts', () => {
     .stdout()
     .command(['domain:delete', domainId])
     .it('runs domain:delete on domain defintion', ctx => {
-      expect(ctx.stdout).to.contains(`Deleted domain '${domainId}'`)
+      expect(ctx.stdout).to.contain(`Deleted domain '${domainId}'`)
     })
 
   test

--- a/test/commands/domain/get.test.js
+++ b/test/commands/domain/get.test.js
@@ -36,7 +36,7 @@ describe('valid identifier on domain:get', () => {
   .stdout()
   .command(['domain:get', 'org1/domain2/1.0.0', '--json'])
   .it('runs domain:get --json and returns response in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
   })
 
   test
@@ -48,7 +48,7 @@ describe('valid identifier on domain:get', () => {
   .stdout()
   .command(['domain:get', 'org1/domain2/1.0.0', '-j'])
   .it('runs domain:get -j and returns response in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
   })
 
   test
@@ -60,7 +60,7 @@ describe('valid identifier on domain:get', () => {
   .stdout()
   .command(['domain:get', 'org1/domain2/1.0.0'])
   .it('runs domain:get and returns response in yaml format', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
   })
 
   test
@@ -76,7 +76,7 @@ describe('valid identifier on domain:get', () => {
   .stdout()
   .command(['domain:get', 'org1/domain2'])
   .it('runs domain:get to return default domain version in yaml format', ctx => {
-    expect(ctx.stdout).to.contains(yaml.dump(jsonResponse))
+    expect(ctx.stdout).to.contain(yaml.dump(jsonResponse))
   })
 
   test
@@ -92,7 +92,7 @@ describe('valid identifier on domain:get', () => {
   .stdout()
   .command(['domain:get', 'org1/domain2', '-j'])
   .it('runs domain:get to return default domain version in json format', ctx => {
-    expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+    expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
   })
 })
 

--- a/test/commands/domain/publish.test.js
+++ b/test/commands/domain/publish.test.js
@@ -12,7 +12,7 @@ describe('valid domain:publish', () => {
   .stdout()
   .command(['domain:publish', 'org/domain/1.0.0'])
   .it('runs domain:publish with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Published domain org/domain/1.0.0')
+    expect(ctx.stdout).to.contain('Published domain org/domain/1.0.0')
   })
 })
 

--- a/test/commands/domain/setdefault.test.js
+++ b/test/commands/domain/setdefault.test.js
@@ -12,7 +12,7 @@ describe('valid domain:setdefault', () => {
   .stdout()
   .command(['domain:setdefault', 'org/domain/2.0.0'])
   .it('runs domain:setdefault with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+    expect(ctx.stdout).to.contain('Default version of org/domain set to 2.0.0')
   })
 })
 

--- a/test/commands/domain/unpublish.test.js
+++ b/test/commands/domain/unpublish.test.js
@@ -12,7 +12,7 @@ describe('valid domain:unpublish', () => {
   .stdout()
   .command(['domain:unpublish', 'org/domain/1.0.0'])
   .it('runs domain:unpublish with identifier', ctx => {
-    expect(ctx.stdout).to.contains('Unpublished domain org/domain/1.0.0')
+    expect(ctx.stdout).to.contain('Unpublished domain org/domain/1.0.0')
   })
 })
 

--- a/test/commands/domain/update.test.js
+++ b/test/commands/domain/update.test.js
@@ -12,7 +12,7 @@ describe('invalid domain:update command issues', () => {
   test
     .command(['domain:update', 'invalid'])
     .catch(err => {
-      expect(err.message).to.contains('No updates specified')
+      expect(err.message).to.contain('No updates specified')
     })
     .it('runs domain:update with no required --file flag')
 
@@ -111,7 +111,7 @@ describe('invalid domain:update', () => {
     )
     .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('Unknown domain org/domain/1.0.0')
+      expect(err.message).to.contain('Unknown domain org/domain/1.0.0')
     })
     .it('error shows as update failed and publish and setdefault are not executed')
 
@@ -131,7 +131,7 @@ describe('invalid domain:update', () => {
     )
     .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--setdefault', '--published=publish'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Publishing domain failed')
+      expect(err.message).to.contain('An error occurred. Publishing domain failed')
     })
     .it('error shows as publish failed and setdefault is not executed')
 
@@ -155,7 +155,7 @@ describe('invalid domain:update', () => {
     )
     .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--published=publish', '--setdefault'])
     .catch(err => {
-      expect(err.message).to.contains('An error occurred. Setting default version failed')
+      expect(err.message).to.contain('An error occurred. Setting default version failed')
     })
     .it('error shows as setdefault failed')
 
@@ -166,7 +166,7 @@ describe('invalid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0'])
 
     .catch(err => {
-      expect(err.message).to.contains('No updates specified')
+      expect(err.message).to.contain('No updates specified')
     })
     .it('error shows as no flag is provided')
 })
@@ -186,7 +186,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml'])
 
     .it('runs domain:update with YAML file', ctx => {
-      expect(ctx.stdout).to.contains(`Updated domain ${validIdentifier}`)
+      expect(ctx.stdout).to.contain(`Updated domain ${validIdentifier}`)
     })
 
   test
@@ -203,7 +203,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json'])
 
     .it('runs domain:update with JSON file, version read from file', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
     })
 
   test
@@ -220,7 +220,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility=public'])
 
     .it('runs domain:update to set domain public', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
     })
 
   test
@@ -237,7 +237,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--visibility=private'])
 
     .it('runs domain:update to set domain private', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
     })
 
   test
@@ -255,7 +255,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '--visibility=public'])
 
     .it('runs domain:update to set domain public without a version arg', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Updated visibility of org/domain/2.0.0 to public')
     })
 
   test
@@ -273,7 +273,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--visibility=private'])
 
     .it('runs domain:update to set domain private', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to private')
+      expect(ctx.stdout).to.contain('Updated visibility of org/domain/2.0.0 to private')
     })
 
   test
@@ -294,8 +294,8 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--published=publish'])
 
     .it('runs domain:update to publish domain', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Published domain org/domain/1.2.3')
     })
 
   test
@@ -316,8 +316,8 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--published=unpublish'])
 
     .it('runs domain:update to unpublish domain', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Unpublished domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Unpublished domain org/domain/1.2.3')
     })
 
   test
@@ -338,8 +338,8 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain', '-f=test/resources/valid_domain.json', '--setdefault'])
 
     .it('runs domain:update to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 1.2.3')
     })
 
   test
@@ -364,9 +364,9 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--visibility=public', '--published=publish', '--setdefault'])
 
     .it('runs domain:update to set domain public, publish domain, and set the default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to public')
-      expect(ctx.stdout).to.contains('Published domain org/domain/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated visibility of org/domain/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Published domain org/domain/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 2.0.0')
     })
 
   test
@@ -391,9 +391,9 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--visibility=public', '--published=unpublish', '--setdefault'])
 
     .it('runs domain:update to set domain public, unpublish domain, and set the default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated visibility of org/domain/2.0.0 to public')
-      expect(ctx.stdout).to.contains('Unpublished domain org/domain/2.0.0')
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+      expect(ctx.stdout).to.contain('Updated visibility of org/domain/2.0.0 to public')
+      expect(ctx.stdout).to.contain('Unpublished domain org/domain/2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 2.0.0')
     })
 
   test
@@ -425,9 +425,9 @@ describe('valid domain:update', () => {
     ])
 
     .it('runs domain:update to set domain public, publish domain, and set the default version with file flag', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3 and visibility is set to public')
-      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3 and visibility is set to public')
+      expect(ctx.stdout).to.contain('Published domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 1.2.3')
     })
 
   test
@@ -458,9 +458,9 @@ describe('valid domain:update', () => {
     ])
 
     .it('runs domain:update to publish domain and set default version', ctx => {
-      expect(ctx.stdout).to.contains('Updated domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Published domain org/domain/1.2.3')
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 1.2.3')
+      expect(ctx.stdout).to.contain('Updated domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Published domain org/domain/1.2.3')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 1.2.3')
     })
 
   test
@@ -477,7 +477,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--published=publish'])
 
     .it('runs domain:update to publish domain', ctx => {
-      expect(ctx.stdout).to.contains('Published domain org/domain/2.0.0')
+      expect(ctx.stdout).to.contain('Published domain org/domain/2.0.0')
     })
 
   test
@@ -494,7 +494,7 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--published=unpublish'])
 
     .it('runs domain:update to unpublish domain', ctx => {
-      expect(ctx.stdout).to.contains('Unpublished domain org/domain/2.0.0')
+      expect(ctx.stdout).to.contain('Unpublished domain org/domain/2.0.0')
     })
 
   test
@@ -511,6 +511,6 @@ describe('valid domain:update', () => {
     .command(['domain:update', 'org/domain/2.0.0', '--setdefault'])
 
     .it('runs domain:update to set default version', ctx => {
-      expect(ctx.stdout).to.contains('Default version of org/domain set to 2.0.0')
+      expect(ctx.stdout).to.contain('Default version of org/domain set to 2.0.0')
     })
 })

--- a/test/commands/integration/create.test.js
+++ b/test/commands/integration/create.test.js
@@ -14,7 +14,7 @@ describe('valid integration:create', () => {
     .stdout()
     .command(['integration:create', `${validIdentifier}`, '--file=test/resources/github.json'])
     .it('runs integration:create with json config file', ctx => {
-      expect(ctx.stdout).to.contains('Created integration on API \'org/api/1.0.0\'')
+      expect(ctx.stdout).to.contain('Created integration on API \'org/api/1.0.0\'')
     })
 
   test
@@ -31,7 +31,7 @@ describe('valid integration:create', () => {
     .stdout()
     .command(['integration:create', 'org/api', '--file=test/resources/github.json'])
     .it('runs integration:create on default API version', ctx => {
-      expect(ctx.stdout).to.contains('Created integration on API \'org/api/1.0.0\'')
+      expect(ctx.stdout).to.contain('Created integration on API \'org/api/1.0.0\'')
     })
 })
 
@@ -61,7 +61,7 @@ describe('invalid integration:create', () => {
     )    
     .command(['integration:create', `${validIdentifier}`, '--file=test/resources/github.json'])
     .catch(ctx => {
-      expect(ctx.message).to.contains('Integration \'Integration Name\' already exists')
+      expect(ctx.message).to.contain('Integration \'Integration Name\' already exists')
     })
     .it('runs integration:create with integration name conflict')
 

--- a/test/commands/integration/delete.test.js
+++ b/test/commands/integration/delete.test.js
@@ -22,7 +22,7 @@ describe('valid integration:delete', () => {
     .stdout()
     .command(['integration:delete', `${validApi}/integration-id`])
     .it('runs integration:delete with valid integration', ctx => {
-      expect(ctx.stdout).to.contains("Deleted integration 'integration-id' from API 'org/api/1.0.0'")
+      expect(ctx.stdout).to.contain("Deleted integration 'integration-id' from API 'org/api/1.0.0'")
     })
 })
 

--- a/test/commands/integration/execute.test.js
+++ b/test/commands/integration/execute.test.js
@@ -14,7 +14,7 @@ describe('valid integration:execute', () => {
     .stdout()
     .command(['integration:execute', `${validApi}/integration-id`])
     .it('runs integration:execute with valid integration', ctx => {
-      expect(ctx.stdout).to.contains('Executed integration \'integration-id\' on API \'org/api/1.0.0\'')
+      expect(ctx.stdout).to.contain('Executed integration \'integration-id\' on API \'org/api/1.0.0\'')
     })
 })
 

--- a/test/commands/integration/get.test.js
+++ b/test/commands/integration/get.test.js
@@ -22,7 +22,7 @@ describe('valid integration:get', () => {
     .stdout()
     .command(['integration:get', `${validApi}/integration-id`])
     .it('runs integration:get with valid integration', ctx => {
-      expect(ctx.stdout).to.contains(JSON.stringify(integrationResponse, null, 2))
+      expect(ctx.stdout).to.contain(JSON.stringify(integrationResponse, null, 2))
     })
 })
 

--- a/test/commands/integration/list.test.js
+++ b/test/commands/integration/list.test.js
@@ -29,8 +29,8 @@ describe('valid integration:list', () => {
     .stdout()
     .command(['integration:list', validApi])
     .it('runs integration:list with valid API', ctx => {
-      expect(ctx.stdout).to.contains('12345678-c3d1-41f0-9425-ebdb52c8113c  GitHub Sync  GITHUB           true')
-      expect(ctx.stdout).to.contains('abcdef00-6925-47b9-be97-1d2ba3ddc69a  API Automock API_AUTO_MOCKING false')
+      expect(ctx.stdout).to.contain('12345678-c3d1-41f0-9425-ebdb52c8113c  GitHub Sync  GITHUB           true')
+      expect(ctx.stdout).to.contain('abcdef00-6925-47b9-be97-1d2ba3ddc69a  API Automock API_AUTO_MOCKING false')
     })
 
     test
@@ -46,8 +46,8 @@ describe('valid integration:list', () => {
     .stdout()
     .command(['integration:list', 'org/api'])
     .it('runs integration:list with default API version', ctx => {
-      expect(ctx.stdout).to.contains('12345678-c3d1-41f0-9425-ebdb52c8113c  GitHub Sync  GITHUB           true')
-      expect(ctx.stdout).to.contains('abcdef00-6925-47b9-be97-1d2ba3ddc69a  API Automock API_AUTO_MOCKING false')
+      expect(ctx.stdout).to.contain('12345678-c3d1-41f0-9425-ebdb52c8113c  GitHub Sync  GITHUB           true')
+      expect(ctx.stdout).to.contain('abcdef00-6925-47b9-be97-1d2ba3ddc69a  API Automock API_AUTO_MOCKING false')
     })
 })
 

--- a/test/commands/project/api/add.test.js
+++ b/test/commands/project/api/add.test.js
@@ -32,7 +32,7 @@ describe('valid project:api:add',
             .stdout()
             .command(['project:api:add', `${validIdentifier}`,'testapi'])
             .it('runs project:api:add with \'apis\' spec type', ctx => {
-                expect(ctx.stdout).to.contains('Added api \'testapi\' to project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Added api \'testapi\' to project \'testowner/testproject\'')
             })
     })
 
@@ -46,7 +46,7 @@ describe('invalid project:api:add', () => {
         )
         .command(['project:api:add', `${validIdentifier}`, 'testapi'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+            expect(ctx.message).to.contain('Project \'testproject\' does not exist')
         })
         .it('runs project:api:add with a project that doesn\'t exist')
 
@@ -73,7 +73,7 @@ describe('invalid project:api:add', () => {
         )
         .command(['project:api:add', `${validIdentifier}`, 'testapi'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('The spec already exists in the project')
+            expect(ctx.message).to.contain('The spec already exists in the project')
         })
         .it('runs project:api:add with an api that already exists in the project')
 })

--- a/test/commands/project/api/remove.test.js
+++ b/test/commands/project/api/remove.test.js
@@ -45,7 +45,7 @@ describe('valid project:api:remove', () => {
             .stdout()
             .command(['project:api:remove', `${validIdentifier}`, 'testapi'])
             .it('runs project:api:remove with a valid project and api', ctx => {
-                expect(ctx.stdout).to.contains('Removed api \'testapi\' from project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Removed api \'testapi\' from project \'testowner/testproject\'')
             })
     })
 
@@ -58,7 +58,7 @@ describe('invalid project:api:remove', () => {
         )
         .command(['project:api:remove', `${validIdentifier}`, 'testapi'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+            expect(ctx.message).to.contain('Project \'testproject\' does not exist')
         })
         .it('runs project:api:remove with a project that doesn\'t exist')
 
@@ -70,7 +70,7 @@ describe('invalid project:api:remove', () => {
         )
         .command(['project:api:remove', `${validIdentifier}`, 'testapi'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Organization \'testowner\' does not exist')
+            expect(ctx.message).to.contain('Organization \'testowner\' does not exist')
         })
         .it('runs project:api:remove with an organization that doesn\'t exist')
 
@@ -83,7 +83,7 @@ describe('invalid project:api:remove', () => {
         .stdout()
         .command(['project:api:remove', `${validIdentifier}`, 'invalid'])
         .it('runs project:api:remove with an api that isn\'t in the project', ctx => {
-            expect(ctx.stdout).to.contains('Api \'invalid\' does not exist in project \'testowner/testproject\'')
+            expect(ctx.stdout).to.contain('Api \'invalid\' does not exist in project \'testowner/testproject\'')
         })
 
 })

--- a/test/commands/project/create.test.js
+++ b/test/commands/project/create.test.js
@@ -33,7 +33,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`])
             .it('runs project:create with no flags', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -46,7 +46,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`, '--apis=testapi1,testapi2'])
             .it('runs project:create with --apis flags', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -59,7 +59,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`, '--apis="testapi1, testapi2,     testapi3"'])
             .it('runs project:create with --apis flags with whitespace characters', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -72,7 +72,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`, '--domains="testdomain1,  testdomain2,        testdomain3"'])
             .it('runs project:create with --domains flags with whitespace characters', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -85,7 +85,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`, '--domains=testdomain1,testdomain2'])
             .it('runs project:create with --domains flags', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -98,7 +98,7 @@ describe('valid project:create',
             .stdout()
             .command(['project:create', `${validIdentifier}`, '--description="test project description"'])
             .it('runs project:create with --description flag', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
 
         test
@@ -117,7 +117,7 @@ describe('valid project:create',
                 '--apis=testapi1,testapi2'
             ])
             .it('runs project:create with all valid flags', ctx => {
-                expect(ctx.stdout).to.contains('Created project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Created project \'testowner/testproject\'')
             })
     })
 
@@ -131,7 +131,7 @@ describe('invalid project:create', () => {
         )
         .command(['project:create', `${validIdentifier}`])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Project \'testproject\' already exists')
+            expect(ctx.message).to.contain('Project \'testproject\' already exists')
         })
         .it('runs project:create with project name conflict')
 

--- a/test/commands/project/delete.test.js
+++ b/test/commands/project/delete.test.js
@@ -13,7 +13,7 @@ describe('valid project:delete', () => {
         .stdout()
         .command(['project:delete', 'testowner/testproject'])
         .it('runs project:delete and returns success response', ctx => {
-            expect(ctx.stdout).to.contains(`Deleted project \'${validIdentifier}\'`)
+            expect(ctx.stdout).to.contain(`Deleted project \'${validIdentifier}\'`)
         })
 })
 

--- a/test/commands/project/domain/add.test.js
+++ b/test/commands/project/domain/add.test.js
@@ -32,7 +32,7 @@ describe('valid project:domain:add',
             .stdout()
             .command(['project:domain:add', `${validIdentifier}`, 'testdomain'])
             .it('runs project:domain:add', ctx => {
-                expect(ctx.stdout).to.contains('Added domain \'testdomain\' to project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Added domain \'testdomain\' to project \'testowner/testproject\'')
             })
     })
 
@@ -46,7 +46,7 @@ describe('invalid project:domain:add', () => {
         )
         .command(['project:domain:add', `${validIdentifier}`,'testdomain'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+            expect(ctx.message).to.contain('Project \'testproject\' does not exist')
         })
         .it('runs project:domain:add with a project that doesn\'t exist')
 
@@ -73,7 +73,7 @@ describe('invalid project:domain:add', () => {
         )
         .command(['project:domain:add', `${validIdentifier}`, 'testdomain'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('The spec already exists in the project')
+            expect(ctx.message).to.contain('The spec already exists in the project')
         })
         .it('runs project:domain:add with a domain that already exists in the project')
 })

--- a/test/commands/project/domain/remove.test.js
+++ b/test/commands/project/domain/remove.test.js
@@ -45,7 +45,7 @@ describe('valid project:domain:remove', () => {
             .stdout()
             .command(['project:domain:remove', `${validIdentifier}`, 'testdomain'])
             .it('runs project:domain:remove with a valid project and domain', ctx => {
-                expect(ctx.stdout).to.contains('Removed domain \'testdomain\' from project \'testowner/testproject\'')
+                expect(ctx.stdout).to.contain('Removed domain \'testdomain\' from project \'testowner/testproject\'')
             })
     })
 
@@ -58,7 +58,7 @@ describe('invalid project:domain:remove', () => {
         )
         .command(['project:domain:remove', `${validIdentifier}`, 'testdomain'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Project \'testproject\' does not exist')
+            expect(ctx.message).to.contain('Project \'testproject\' does not exist')
         })
         .it('runs project:domain:remove with a project that doesn\'t exist')
 
@@ -70,7 +70,7 @@ describe('invalid project:domain:remove', () => {
         )
         .command(['project:domain:remove', `${validIdentifier}`, 'testdomain'])
         .catch(ctx => {
-            expect(ctx.message).to.contains('Organization \'testowner\' does not exist')
+            expect(ctx.message).to.contain('Organization \'testowner\' does not exist')
         })
         .it('runs project:domain:remove with an organization that doesn\'t exist')
 
@@ -83,7 +83,7 @@ describe('invalid project:domain:remove', () => {
         .stdout()
         .command(['project:domain:remove', `${validIdentifier}`, 'invalid'])
         .it('runs project:domain:remove with a domain that isn\'t in the project', ctx => {
-            expect(ctx.stdout).to.contains('Domain \'invalid\' does not exist in project \'testowner/testproject\'')
+            expect(ctx.stdout).to.contain('Domain \'invalid\' does not exist in project \'testowner/testproject\'')
         })
 
 })

--- a/test/commands/project/get.test.js
+++ b/test/commands/project/get.test.js
@@ -35,7 +35,7 @@ describe('valid identifier on project:get', () => {
         .stdout()
         .command(['project:get', 'testowner/testproject'])
         .it('runs project:get  returns response in json format', ctx => {
-            expect(ctx.stdout).to.contains(JSON.stringify(jsonResponse, null, 2))
+            expect(ctx.stdout).to.contain(JSON.stringify(jsonResponse, null, 2))
         })
 })
 

--- a/test/commands/project/list.test.js
+++ b/test/commands/project/list.test.js
@@ -31,7 +31,7 @@ describe('valid project:list', () => {
         .stdout()
         .command(['project:list'])
         .it('runs project:list with no arguments and finds no projects', ctx => {
-            expect(ctx.stdout).to.contains('No projects found.')
+            expect(ctx.stdout).to.contain('No projects found.')
         })
 
     test
@@ -43,8 +43,8 @@ describe('valid project:list', () => {
         .stdout()
         .command(['project:list'])
         .it('runs project:list with no arguments ands finds 2 projects', ctx => {
-            expect(ctx.stdout).to.contains('test_project_1')
-            expect(ctx.stdout).to.contains('test_project_2')
+            expect(ctx.stdout).to.contain('test_project_1')
+            expect(ctx.stdout).to.contain('test_project_2')
         })
 
     test
@@ -56,7 +56,7 @@ describe('valid project:list', () => {
         .stdout()
         .command(['project:list', validOrgName])
         .it('runs project:list with org name', ctx => {
-            expect(ctx.stdout).to.contains('test_project_1')
-            expect(ctx.stdout).to.contains('test_project_2')
+            expect(ctx.stdout).to.contain('test_project_1')
+            expect(ctx.stdout).to.contain('test_project_2')
         })
 })

--- a/test/support/parse-input.test.js
+++ b/test/support/parse-input.test.js
@@ -229,7 +229,7 @@ describe('readConfigFile', () => {
     it('should return config content', () => {
       const config = readConfigFile('test/resources/github.json')
       const configString = String.fromCharCode.apply(null, config)
-      expect(configString).to.contains('GitHub Integration Name')
+      expect(configString).to.contain('GitHub Integration Name')
     })
   )
 


### PR DESCRIPTION
This pull request updates the test assertions across several command test suites to use the correct Chai assertion method. Specifically, it replaces `.contains` with `.contain` in all relevant `expect` statements, ensuring proper usage of the Chai library for string containment checks. No functional test logic or behavior is changed; these updates are solely to improve correctness and consistency in the test code.

Test assertion improvements:

* Replaced `.contains` with `.contain` in all `expect` statements in `api/create.test.js` to properly check error and output messages for various `api:create` scenarios. [[1]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL144-R144) [[2]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL165-R165) [[3]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL190-R190) [[4]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL210-R210) [[5]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL231-R231) [[6]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL252-R252) [[7]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL334-R334) [[8]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL356-R356) [[9]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL377-R377) [[10]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL400-R400) [[11]](diffhunk://#diff-bc55c75391c7fc38948c6ba8ea9636e7efc8b1af04ae2418a4c48da3c4f2098dL425-R425)
* Updated `.contains` to `.contain` in `api/delete.test.js` for output validation when deleting API versions and definitions. [[1]](diffhunk://#diff-ccfe097f05d7653864977d1d47831d1c385d78b920cc9327d663b1bfc21c6dc8L18-R18) [[2]](diffhunk://#diff-ccfe097f05d7653864977d1d47831d1c385d78b920cc9327d663b1bfc21c6dc8L31-R31) [[3]](diffhunk://#diff-ccfe097f05d7653864977d1d47831d1c385d78b920cc9327d663b1bfc21c6dc8L50-R50) [[4]](diffhunk://#diff-ccfe097f05d7653864977d1d47831d1c385d78b920cc9327d663b1bfc21c6dc8L62-R62)
* Updated `.contains` to `.contain` in `api/get.test.js` for output validation in both JSON and YAML response formats. [[1]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL38-R38) [[2]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL50-R50) [[3]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL62-R62) [[4]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL78-R78) [[5]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL94-R94) [[6]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL106-R106) [[7]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL122-R122) [[8]](diffhunk://#diff-530b65089c58837a53417736f2d0c43ddf9d64969a37c329cd515335e9334ccfL134-R134)
* Updated `.contains` to `.contain` in `api/publish.test.js`, `api/setdefault.test.js`, and `api/unpublish.test.js` for publish, setdefault, and unpublish command output assertions. [[1]](diffhunk://#diff-7561c8e16cec1a6dbef2cc43d380e7fd2eb141fd29330f5cd05976abfc4a77e7L17-R17) [[2]](diffhunk://#diff-7561c8e16cec1a6dbef2cc43d380e7fd2eb141fd29330f5cd05976abfc4a77e7L44-R44) [[3]](diffhunk://#diff-cf0db17ab06cca87806cbfedeabce5858760d9395c1cba505da5656ca226464cL15-R15) [[4]](diffhunk://#diff-74465c1f95239099107788669359e0fff86214007f4ca07542032ea669a62281L15-R15)
* Updated `.contains` to `.contain` in `api/update.test.js` for both error and success output assertions in various `api:update` scenarios. [[1]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L15-R15) [[2]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L114-R114) [[3]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L134-R134) [[4]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L158-R158) [[5]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L169-R169) [[6]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L189-R189) [[7]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L206-R206) [[8]](diffhunk://#diff-baf3b2a28725e59d011a2865ff54a656648c0243e6e544f9752185ce64134377L223-R223)