### PR TITLE
chore(ci): upgrade actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         node-version: [ 20.x, 22.x ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Extract version from source branch name
         id: extract_version
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - run: echo "Creating GitHub release for version ${{ env.VERSION }}"
       - name: Create GitHub Release
@@ -75,13 +75,13 @@ jobs:
       VERSION: ${{ needs.version-and-tag.outputs.VERSION }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.VERSION }}
 
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [ 20.x, 22.x ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/release-on-github.yaml
+++ b/.github/workflows/release-on-github.yaml
@@ -24,9 +24,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
 


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to use the latest major versions of `actions/checkout` and `actions/setup-node`. These upgrades ensure we're using the most recent features and security patches provided by GitHub for our CI/CD pipelines.

**Workflow dependency upgrades:**

* Updated `actions/checkout` to version `v6` in all workflows, including `build-main.yaml`, `codeql.yml`, `deploy-release.yaml`, `pull-request.yaml`, and `release-on-github.yaml`. [[1]](diffhunk://#diff-ed9008ce7f1c6c1ded18f4804e75aeb30f94697dc2eef5a1e5e2f5b1e73fd278L14-R16) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L47-R47) [[3]](diffhunk://#diff-d8afbe8d1fc0b9fe347759a07853b35b70b0f3e4b1a22ded2ad0a5e1f6b28b76L22-R22) [[4]](diffhunk://#diff-d8afbe8d1fc0b9fe347759a07853b35b70b0f3e4b1a22ded2ad0a5e1f6b28b76L54-R54) [[5]](diffhunk://#diff-d8afbe8d1fc0b9fe347759a07853b35b70b0f3e4b1a22ded2ad0a5e1f6b28b76L78-R84) [[6]](diffhunk://#diff-a8619735ff14304aa0514284f86ff5145b0a6bae2e76a37faeb0ad899a3d8db4L12-R14) [[7]](diffhunk://#diff-fc00ce6c11e271e0c8f700afbad93ef38e063a600c0449a884209770c2365c27L27-R29)
* Updated `actions/setup-node` to version `v6` wherever Node.js setup is required, ensuring consistency and access to the latest features. [[1]](diffhunk://#diff-ed9008ce7f1c6c1ded18f4804e75aeb30f94697dc2eef5a1e5e2f5b1e73fd278L14-R16) [[2]](diffhunk://#diff-d8afbe8d1fc0b9fe347759a07853b35b70b0f3e4b1a22ded2ad0a5e1f6b28b76L78-R84) [[3]](diffhunk://#diff-a8619735ff14304aa0514284f86ff5145b0a6bae2e76a37faeb0ad899a3d8db4L12-R14) [[4]](diffhunk://#diff-fc00ce6c11e271e0c8f700afbad93ef38e063a600c0449a884209770c2365c27L27-R29)

These changes help keep our workflows up-to-date and reduce the risk of issues caused by outdated action versions.

// Give a brief summary of changes introduced

* [x] I have added the appropriate label to my PR