### PR TITLE
fix: suppress deprecated punycode module warning

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// Suppress the deprecated punycode module warning
+// https://nodejs.org/api/deprecations.html#deprecations_dep0040_the_punycode_module_is_deprecated
+process.noDeprecation = true;
+
 require('@oclif/core').run()
 .then(require('@oclif/core/flush'))
 .catch(require('@oclif/core/handle'))


### PR DESCRIPTION
This PR hides the punycode no-userland deprecation warning.

* [X] I have added the appropriate label to my PR