### PR TITLE
chore: update dependencies for serialize-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,16 +37,16 @@
         "eslint-plugin-node": "^11.1.0",
         "globby": "^14.0.0",
         "husky": "^9.0.1",
-        "mocha": "^11.7.5",
+        "mocha": "^11.7.6",
         "nock": "^14.0.1",
         "nyc": "^18.0.0",
         "rewire": "^7.0.0",
         "sinon": "^19.0.2",
-        "tmp": "^0.2.5"
+        "tmp": "^0.2.7"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0",
-        "npm": ">=11.0.0"
+        "npm": ">=11.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.3.0.tgz",
-      "integrity": "sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
       "dev": true,
       "funding": [
         {
@@ -4394,9 +4394,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6995,16 +6995,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -7539,13 +7529,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {
@@ -8052,9 +8042,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -32,20 +32,21 @@
     "eslint-plugin-node": "^11.1.0",
     "globby": "^14.0.0",
     "husky": "^9.0.1",
-    "mocha": "^11.7.5",
+    "mocha": "^11.7.6",
     "nock": "^14.0.1",
     "nyc": "^18.0.0",
     "rewire": "^7.0.0",
     "sinon": "^19.0.2",
-    "tmp": "^0.2.5"
+    "tmp": "^0.2.7"
   },
   "engines": {
     "node": "^20.17.0 || >=22.9.0",
-    "npm": ">=11.0.0"
+    "npm": ">=11.9.0"
   },
   "overrides": {
     "npm": "^11.9.0",
-    "glob": "^10.5.0"
+    "glob": "^10.5.0",
+    "serialize-javascript": "^7.0.5"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
This pull request updates several development dependencies and engine requirements in the `package.json` file to ensure compatibility and address potential security or stability issues.

Dependency and engine updates:

* Updated `mocha` from version `^11.7.5` to `^11.7.6` and `tmp` from `^0.2.5` to `^0.2.7` in the `devDependencies` section.
* Increased the minimum required `npm` version from `>=11.0.0` to `>=11.9.0` in the `engines` section.
* Added an override for `serialize-javascript` at version `^7.0.5` and updated the `glob` override to `^10.5.0`.

Fixes SWG-19641