### PR TITLE
fix: await archive finalization in upload process

### DIFF
--- a/src/commands/spectral/upload.js
+++ b/src/commands/spectral/upload.js
@@ -21,7 +21,7 @@ class UploadSpectralRulesetCommand extends BaseCommand {
     const passthrough = new PassThrough();
 
     archive.directory(directoryPath, false);
-    archive.finalize();
+    await archive.finalize();
     archive.pipe(passthrough);
     return passthrough;
   }


### PR DESCRIPTION
This pull request updates the `UploadSpectralRulesetCommand` to properly handle the asynchronous finalization of the archive stream. The most important change is:

- Awaited the `archive.finalize()` call in the `UploadSpectralRulesetCommand` to ensure the archive is fully finalized before proceeding, improving reliability when streaming the archive.