### PR TITLE
fix: handle 401 responses for domain operations (SWG-20526)

### DIFF
--- a/src/support/command/handle-response.js
+++ b/src/support/command/handle-response.js
@@ -27,7 +27,7 @@ const checkForErrors = ({ resolveStatus = [] } = {}) => response => {
 }
 
 const filterResponseMessaging = response => {
-  if (response.status === 403) {
+  if (response.status === 401 || response.status === 403) {
     return Promise.reject(response)
   }
 

--- a/test/commands/domain/create.test.js
+++ b/test/commands/domain/create.test.js
@@ -115,6 +115,38 @@ describe('invalid domain:create', () => {
       expect(ctx.message).to.equal('You have reached the limit of domains')
     })
     .it('runs domain:create with org that doesn\'t exist')
+
+  test
+    .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain')
+      .reply(404)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0&isPrivate=true')
+      .reply(401, '{"code":401,"message":"Invalid API key"}')
+    )
+    .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Invalid API key')
+    })
+    .it('runs domain:create with invalid API key returns 401')
+
+  test
+    .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain')
+      .reply(404)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0&isPrivate=true')
+      .reply(415, '{"code":415,"message":"Unsupported Media Type"}')
+    )
+    .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Unsupported Media Type')
+    })
+    .it('runs domain:create with unsupported content type returns 415')
   
   test
     .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))

--- a/test/commands/domain/delete.test.js
+++ b/test/commands/domain/delete.test.js
@@ -73,6 +73,19 @@ describe('domain:delete error responses', () => {
       expect(ctx.message).to.contain(`Unknown domain ${domainId}`)
     })
     .it('runs domain:delete with domain that does not exist')
+
+  test
+    .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .delete('/org/domain/1.0.0')
+      .query({ force: 'true' })
+      .reply(401, '{"code":401,"message":"Invalid API key"}')
+    )
+    .command(['domain:delete', versionId])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('Invalid API key')
+    })
+    .it('runs domain:delete with invalid API key returns 401')
 })
 
 

--- a/test/commands/domain/update.test.js
+++ b/test/commands/domain/update.test.js
@@ -107,6 +107,38 @@ describe('invalid domain:update', () => {
     .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
     .nock(`${shubUrl}/domains`, domain => domain
       .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(401, '{"code":401,"message":"Invalid API key"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Invalid API key')
+    })
+    .it('runs domain:update with invalid API key returns 401')
+
+  test
+    .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
+      .reply(200)
+    )
+    .nock(`${shubUrl}/domains`, domain => domain
+      .post('/org/domain?version=1.0.0')
+      .reply(415, '{"code":415,"message":"Unsupported Media Type"}')
+    )
+    .command(['domain:update', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.equal('Unsupported Media Type')
+    })
+    .it('runs domain:update with unsupported content type returns 415')
+
+  test
+    .stub(config, 'getConfig', stub => stub.returns({ SWAGGERHUB_URL: shubUrl }))
+    .nock(`${shubUrl}/domains`, domain => domain
+      .get('/org/domain/1.0.0')
       .reply(404, '{"code": 404, "message": "Unknown domain org/domain/1.0.0"}')
     )
     .command(['domain:update', `${validIdentifier}`, '-f=test/resources/valid_domain.yaml', '--published=publish', '--setdefault'])


### PR DESCRIPTION
## Summary

Follows registry PR [#2958 (SWG-20526)](https://github.com/SmartBear/swaggerhub-registry-api/pull/2958), which made these spec-correctness fixes to domain operations:

- `saveDomainDefinition` now returns **400** (blank body) and **415** (unsupported content type) instead of 500
- `deleteDomain`, `deleteDomainVersion`, `renameDomain`, `forkDomain`, `cloneDomain` now return **401** for invalid tokens instead of the undocumented 403

### Changes

**`src/support/command/handle-response.js`**

`filterResponseMessaging` previously only rejected 403 responses. Added 401 to the condition as defense-in-depth: if a 401 response ever reaches this function (e.g. via a future `resolveStatus: [401]`), it is rejected and surfaced as an error rather than silently passed to `onResolve`. In the current call sites 401 is already caught earlier by `checkForErrors`, so this is a safeguard for future code.

**Tests**

Added tests that verify the CLI correctly surfaces errors for the new response codes from the registry:

| Test file | New cases |
|---|---|
| `test/commands/domain/create.test.js` | 401 on POST (invalid API key), 415 on POST (unsupported content type) |
| `test/commands/domain/delete.test.js` | 401 on DELETE (invalid API key) |
| `test/commands/domain/update.test.js` | 401 on POST (invalid API key), 415 on POST (unsupported content type) |

All 435 existing tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016stuqDZQnQDtZD5XTqj635)_