### PR TITLE
SWG-20670 introduce 10mb limit for API and domain specifications

### DIFF
--- a/src/template-strings/errors.js
+++ b/src/template-strings/errors.js
@@ -21,6 +21,8 @@ const errorMsg = {
 
   fileNotFound: 'File \'{{filename}}\' not found',
 
+  fileTooLarge: 'File \'{{filename}}\' exceeds the maximum allowed size of {{maxSizeMB}}MB.',
+
   invalidConfig: 'Invalid configuration file. Please ensure that the file is in JSON format',
 
   directoryExists: 'Directory already exists: \'{{directory}}\'',

--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -1,7 +1,10 @@
 const { CLIError } = require('@oclif/core').Errors
 const { hasJsonStructure } = require('./general')
 const yaml = require('js-yaml')
-const { existsSync, readFileSync } = require('fs-extra')
+const fsExtra = require('fs-extra')
+const { existsSync, readFileSync } = fsExtra
+
+const MAX_SPEC_SIZE_BYTES = 10 * 1024 * 1024
 const { errorMsg } = require('../template-strings')
 
 const specVersionToSpecification = specVersion => {
@@ -32,6 +35,10 @@ const getVersion = definition => {
 const parseDefinition = filename => {
   if (!existsSync(filename)) {
     throw new CLIError(errorMsg.fileNotFound({ filename }))
+  }
+  const { size } = fsExtra.statSync(filename)
+  if (size > MAX_SPEC_SIZE_BYTES) {
+    throw new CLIError(errorMsg.fileTooLarge({ filename, maxSizeMB: 10 }))
   }
   const file = readFileSync(filename)
   if (file.length === 0) {

--- a/test/commands/api/create.test.js
+++ b/test/commands/api/create.test.js
@@ -1,5 +1,6 @@
 const { expect, test } = require('@oclif/test')
 const config = require('../../../src/config')
+const fsExtra = require('fs-extra')
 const validIdentifier = 'org/api/1.0.0'
 const shubUrl = 'https://test-api.swaggerhub.com'
 
@@ -48,6 +49,14 @@ describe('invalid api:create file issues', () => {
       expect(ctx.message).to.contain('Cannot determine version from file')
     })
     .it('runs api:create with file missing version')
+
+  test
+    .stub(fsExtra, 'statSync', stub => stub.returns({ size: 11 * 1024 * 1024 }))
+    .command(['api:create', validIdentifier, '--file=test/resources/valid_api.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/valid_api.json\' exceeds the maximum allowed size of 10MB.')
+    })
+    .it('runs api:create with file exceeding 10MB size limit')
 })
 
 describe('invalid api:create', () => {

--- a/test/commands/api/update.test.js
+++ b/test/commands/api/update.test.js
@@ -1,5 +1,6 @@
 const { expect, test } = require('@oclif/test')
 const config = require('../../../src/config')
+const fsExtra = require('fs-extra')
 const validIdentifier = 'org/api/1.0.0'
 const shubUrl = 'https://test-api.swaggerhub.com'
 
@@ -66,6 +67,14 @@ describe('invalid api:update file issues', () => {
       expect(ctx.message).to.contain('Cannot determine version from file')
     })
     .it('runs api:update with file missing version')
+
+  test
+    .stub(fsExtra, 'statSync', stub => stub.returns({ size: 11 * 1024 * 1024 }))
+    .command(['api:update', `${validIdentifier}`, '--file=test/resources/valid_api.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/valid_api.json\' exceeds the maximum allowed size of 10MB.')
+    })
+    .it('runs api:update with file exceeding 10MB size limit')
 })
 
 describe('invalid api:update', () => {

--- a/test/commands/domain/create.test.js
+++ b/test/commands/domain/create.test.js
@@ -1,5 +1,6 @@
 const { expect, test } = require('@oclif/test')
 const config = require('../../../src/config')
+const fsExtra = require('fs-extra')
 const validIdentifier = 'org/domain/1.0.0'
 const shubUrl = 'https://test-api.swaggerhub.com'
 
@@ -41,6 +42,14 @@ describe('invalid domain:create file issues', () => {
       expect(ctx.message).to.contain('Cannot determine version from file')
     })
     .it('runs domain:create with file missing version')
+
+  test
+    .stub(fsExtra, 'statSync', stub => stub.returns({ size: 11 * 1024 * 1024 }))
+    .command(['domain:create', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/valid_domain.json\' exceeds the maximum allowed size of 10MB.')
+    })
+    .it('runs domain:create with file exceeding 10MB size limit')
 })
 
 describe('invalid domain:create', () => {

--- a/test/commands/domain/update.test.js
+++ b/test/commands/domain/update.test.js
@@ -1,5 +1,6 @@
 const { expect, test } = require('@oclif/test')
 const config = require('../../../src/config')
+const fsExtra = require('fs-extra')
 const validIdentifier = 'org/domain/1.0.0'
 const shubUrl = 'https://test-api.swaggerhub.com'
 
@@ -66,6 +67,14 @@ describe('invalid domain:update file issues', () => {
       expect(ctx.message).to.contain('Cannot determine version from file')
     })
     .it('runs domain:update with file missing version')
+
+  test
+    .stub(fsExtra, 'statSync', stub => stub.returns({ size: 11 * 1024 * 1024 }))
+    .command(['domain:update', `${validIdentifier}`, '--file=test/resources/valid_domain.json'])
+    .catch(ctx => {
+      expect(ctx.message).to.contain('File \'test/resources/valid_domain.json\' exceeds the maximum allowed size of 10MB.')
+    })
+    .it('runs domain:update with file exceeding 10MB size limit')
 })
 
 describe('invalid domain:update', () => {


### PR DESCRIPTION

## Summary

- Add `fileTooLarge` error template to `src/template-strings/errors.js`
- Add `MAX_SPEC_SIZE_BYTES` constant and `statSync` size check to `parseDefinition()` in `src/utils/definitions.js`
- Add size-limit test cases to all four affected commands: `api:create`, `api:update`, `domain:create`, `domain:update`

## Problem

SwaggerHub Frontend BFF enforces a 10MB limit on spec uploads. The CLI had no client-side check, allowing files up to ~15MB through before hitting the downstream Registry service's `postBody` limit — producing an opaque server-side error instead of a clear early failure.

## Solution

Centralised size check in `parseDefinition()`, which all four affected commands call before constructing the request body. If the file exceeds 10MB the CLI exits immediately with a clear error message and makes no HTTP request.

```
File 'path/to/spec.yaml' exceeds the maximum allowed size of 10MB.
```

The 10MB constant (`MAX_SPEC_SIZE_BYTES`) is defined once in `definitions.js`. The check uses `statSync` to read only the file size, avoiding loading the full file into memory.

## Out of scope

- `spectral upload` — streams a zip archive, different code path
- `api validate:local` — reads file for local linting only, no POST involved
- `integration create` — payload is a config JSON, not a spec